### PR TITLE
make WAF URL explicit

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 VUE_APP_OAPI=http://localhost:8999/pygeoapi
 VUE_APP_MQTT=mqtt://localhost:1883
+VUE_APP_WAF=mqtt://localhost:8999/data/

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -17,7 +17,7 @@ export default {
       services: {
         API: process.env.VUE_APP_OAPI,
         MQTT: process.env.VUE_APP_MQTT,
-        WAF: '/data/'
+        WAF: process.env.VUE_APP_WAF
       },
     };
   },


### PR DESCRIPTION
Make WAF URL absolute (looks nicer on UI, and allows for decoupling from UI infrastructure).