### PR TITLE
Add simple Datatable to station dialog

### DIFF
--- a/src/components/ChartDialog.vue
+++ b/src/components/ChartDialog.vue
@@ -7,7 +7,7 @@
             <v-row>
               <v-card-title class="ml-2 mt-2" v-html="station.properties.name" />
               <v-spacer />
-              <v-btn  class="mr-2 mt-2" large rounded dark @click="$root.toggleDialog"> X </v-btn>
+              <v-btn class="mr-2 mt-2" @click="$root.toggleDialog"> X </v-btn>
             </v-row>
           </v-card-actions>
           <v-card-text>
@@ -34,8 +34,16 @@
                     v-html="$t('chart.chart')"
                   />
                 </tab>
+                <tab :val="3">
+                  <v-btn
+                    flat
+                    @click="selectedTab = 3"
+                    v-html="$t('table.table')"
+                  />
+                </tab>
               </tabs>
             </v-card>
+
             <v-card flat height="590">
               <div v-show="selectedTab === 0">
                 <wis-map
@@ -66,9 +74,9 @@
                   </v-row>
                 </v-card>
               </div>
-              <div v-show="selectedTab === 2">
+              <div v-show="selectedTab === 2 || selectedTab === 3">
                 <v-container fluid>
-                  <plotter-dialog :station="station.id" />
+                  <plotter-dialog :choice="selectedTab" :station="station.id" />
                 </v-container>
               </div>
             </v-card>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -76,6 +76,7 @@ export default defineComponent({
       return new Date(date).toLocaleString(this.$t("code"), {
         timeZoneName: "short",
         timeZone: "UTC",
+        hour12: false,
       });
     },
     getCol(features, key) {

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -1,39 +1,51 @@
-<template id="plotter-chart">
-  <div class="plotter-chart">
+<template id="data-table">
+  <div class="data-table">
+    <v-table v-show="title !== ''">
+      <template v-slot:default>
+        <thead>
+          <tr>
+            <th class="text-center" v-html="$t('table.time')" />
+            <th class="text-center" v-html="title" />
+          </tr>
+        </thead>
+      </template>
+    </v-table>
+
     <v-alert v-show="alert.value" type="warning" v-html="alert.msg" />
 
-    <v-card min-height="600px">
-      <div :style="{ visibility: loading ? 'visible' : 'hidden' }">
-        <v-progress-linear striped indeterminate color="primary" />
-      </div>
-      <div :style="{ visibility: !loading ? 'visible' : 'hidden' }">
-        <v-container>
-          <v-row justify="center" align="end">
-            <div :id="'plotly-chart-' + choices_.collection.id" />
-          </v-row>
-        </v-container>
-      </div>
+    <v-card id="scroll-target" class="overflow-y-auto" max-height="500">
+      <v-table v-scroll:#scroll-target="onScroll">
+        <template v-slot:default>
+          <tbody>
+            <tr v-for="(date, index) in data.time" :key="index">
+              <td v-html="formatDate(date)" />
+              <td v-html="data.value[index]" />
+            </tr>
+          </tbody>
+        </template>
+      </v-table>
     </v-card>
   </div>
 </template>
 
 <script>
-import Plotly from "plotly.js-dist-min";
 import { defineComponent } from "vue";
-import { mdiDownload } from "@mdi/js";
 
 let oapi = process.env.VUE_APP_OAPI;
 
 export default defineComponent({
-  name: "PlotterChart",
-  template: "#plotter-chart",
+  name: "DataTable",
+  template: "#data-table",
   props: ["choices"],
   watch: {
-    choices_: {
+    choices: {
       handler(newValue) {
+        if (this.loading === true) {
+          return;
+        }
+        this.loading = true;
         if (newValue.collection !== "" && newValue.datastream !== "") {
-          this.data = [];
-          this.config.modeBarButtonsToAdd = [];
+          this.data = {};
           for (var station of this.choices_.station) {
             this.loadCollection(newValue.collection, station);
           }
@@ -45,33 +57,11 @@ export default defineComponent({
   },
   data: function () {
     return {
-      trace: {
-        type: "scatter",
-        mode: "lines+markers",
-        x: [],
-        y: [],
-      },
       choices_: this.choices,
-      data: [],
+      data: {},
       loading: false,
-      layout: {
-        title: "",
-        xaxis: {
-          autorange: true,
-          type: "date",
-          range: [null, null],
-          rangeslider: { range: [null, null] },
-        },
-        yaxis: {
-          type: "linear",
-          autorange: true,
-          title: null,
-        },
-      },
-      config: {
-        modeBarButtonsToAdd: [],
-      },
-      font: { size: 14 },
+      title: "",
+      headerOverflow: 0,
       alert: {
         value: false,
         msg: "",
@@ -79,13 +69,14 @@ export default defineComponent({
     };
   },
   methods: {
-    plot() {
-      var plot = document.getElementById(
-        "plotly-chart-" + this.choices.collection.id
-      );
-      Plotly.purge(plot);
-      Plotly.newPlot(plot, this.data, this.layout, this.config);
-      this.loading = false;
+    onScroll(e) {
+      this.headerOverflow = e.target.scrollTop;
+    },
+    formatDate(date) {
+      return new Date(date).toLocaleString(this.$t("code"), {
+        timeZoneName: "short",
+        timeZone: "UTC",
+      });
     },
     getCol(features, key) {
       if (key.includes(".")) {
@@ -105,21 +96,14 @@ export default defineComponent({
         });
       }
     },
-    newTrace(features, x, y, station_id) {
-      const Trace = JSON.parse(JSON.stringify(this.trace));
-      Trace.x = this.getCol(features, x);
-      Trace.y = this.getCol(features, y);
-      Trace.name = station_id;
-      this.data.push(Trace);
+    newTable(features, colName) {
+      this.data.time = this.getCol(features, "phenomenonTime");
+      this.data.value = this.getCol(features, colName);
+      this.loading = false;
     },
     async loadCollection(collection, station_id) {
       this.loading = true;
       var self = this;
-      const range = this.layout.xaxis.range;
-      const title = collection.description;
-      this.layout.title = title;
-      this.layout.xaxis.range = range;
-      this.layout.xaxis.rangeslider = { range: range };
 
       await this.$http({
         method: "get",
@@ -152,7 +136,6 @@ export default defineComponent({
         this.alert.msg =
           station_id + " has no observations in collection: " + collection_id;
         this.alert.value = true;
-        this.loading = false;
         return;
       } else {
         var self = this;
@@ -169,30 +152,15 @@ export default defineComponent({
         })
           .then(function (response) {
             // handle success
-            self.config.modeBarButtonsToAdd.push({
-              name: "Data Source " + station_id,
-              icon: {
-                width: 24,
-                height: 24,
-                path: mdiDownload,
-              },
-              click: function () {
-                window.location.href = response.request.responseURL;
-              },
-            });
-            var title =
+            self.title =
               self.choices_.datastream.name +
               " (" +
               self.choices_.datastream.units +
               ")";
-            self.layout.yaxis.title = title;
-            self.newTrace(
+            self.newTable(
               response.data.features,
-              "phenomenonTime",
-              "observations." + self.choices_.datastream.id + ".value",
-              station_id
+              "observations." + self.choices_.datastream.id + ".value"
             );
-            self.plot();
           })
           .catch(function (error) {
             // handle error

--- a/src/components/PlotterDialog.vue
+++ b/src/components/PlotterDialog.vue
@@ -2,11 +2,14 @@
   <div class="plotter-dialog">
     <v-container fluid>
       <v-row fill-height>
-        <v-col cols="3">
-          <plotter-navigation :choices="choices" />
-        </v-col>
+        <plotter-navigation :choices="choices" />
         <v-col cols="9" offset="3">
-          <plotter-chart :choices="choices" />
+          <template v-if="choice === 2">
+            <plotter-chart :choices="choices" />
+          </template>
+          <template v-else-if="choice === 3">
+            <data-table :choices="choices" />
+          </template>
         </v-col>
       </v-row>
     </v-container>
@@ -18,16 +21,18 @@
 <script>
 import PlotterChart from "@/components/PlotterChart.vue";
 import PlotterNavigation from "@/components/PlotterNavigation.vue";
+import DataTable from "@/components/DataTable.vue";
 let oapi = process.env.VUE_APP_OAPI;
 import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "PlotterDialog",
   template: "#plotter-dialog",
-  props: ["station"],
+  props: ["station", "choice"],
   components: {
     PlotterChart,
     PlotterNavigation,
+    DataTable,
   },
   data() {
     return {
@@ -45,6 +50,14 @@ export default defineComponent({
   methods: {
     goBack() {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push("/");
+    },
+  },
+  watch: {
+    choice: {
+      handler() {
+        this.choices.datastream = "";
+        this.choices.collection = "";
+      }
     },
   },
   async created() {

--- a/src/components/PlotterNavigation.vue
+++ b/src/components/PlotterNavigation.vue
@@ -22,13 +22,9 @@
                     v-for="(item, i) in choices.collections"
                     :key="i"
                     link
+                    @click="updateCollection(item)"
                   >
-                    <v-btn
-                      dark
-                      block
-                      @click="updateCollection(item)"
-                      v-html="item.title"
-                    />
+                    <v-list-item-title v-html="clean(item.title)" />
                   </v-list-item>
                 </v-list>
               </v-card>
@@ -38,7 +34,7 @@
 
             <v-list-item-subtitle v-html="$t('chart.observed_property')" />
             <v-divider class="mb-2" />
-            <v-menu absolute offset-y>
+            <v-menu app offset-x close-on-click>
               <template v-slot:activator="{ props }">
                 <v-btn color="primary" dark text block v-bind="props">
                   <v-list-item-text v-html="choices.datastream.name" />
@@ -50,13 +46,9 @@
                     v-for="(val, key, i) in choices.datastreams"
                     :key="i"
                     link
+                    @click="updateData(key)"
                   >
-                    <v-btn
-                      dark
-                      block
-                      @click="updateData(key)"
-                      v-html="clean(key)"
-                    />
+                    <v-list-item-text v-html="clean(key)" />
                   </v-list-item>
                 </v-list>
               </v-card>
@@ -96,7 +88,11 @@ export default {
       this.choices_.datastream.name = this.clean(newD);
     },
     clean(word) {
-      return word.replaceAll("_", " ");
+      if (typeof word === "string") {
+        return (
+          word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+        ).replaceAll("_", " ");
+      }
     },
   },
 };

--- a/src/locales/_template.json
+++ b/src/locales/_template.json
@@ -26,5 +26,9 @@
     "collection": "",
     "observed_property'": "",
     "station": ""
+  },
+  "table": {
+    "table": "",
+    "time": ""
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,5 +26,9 @@
     "collection": "Collection",
     "observed_property": "Observed Property",
     "station": "Stations"
+  },
+  "table": {
+    "table": "Table",
+    "time": "Phenomenon Time"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -26,5 +26,9 @@
     "collection": "Colección",
     "observed_property": "Propiedad observada",
     "station": "Estación"
+  },
+  "table": {
+    "table": "Tabla",
+    "time": "Tiempo de fenómeno"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -26,5 +26,9 @@
     "collection": "Collection",
     "observed_property": "Propriété observée",
     "station": "Station"
+  },
+  "table": {
+    "table": "Tableau",
+    "time": "Heure du phénomène"
   }
 }


### PR DESCRIPTION
- Create DataTable.vue.
- Update PlotterNavigation.vue & PlotterDialog.vue to serve a data table as well as the Plotly plot.
- Add tab for datatable to dialog.
- Replace console log with alert box in the dialog when there are no observations in a collection from a station.
- Add translations for table.
- Can serve better datatable from vuetify when https://next.vuetifyjs.com/en/components/data-tables/ is added.

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/40066515/156047739-954791b1-34a6-4bec-bc17-22c993a96ba4.png">

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/40066515/156047558-1da59887-c957-4381-9ddb-f0b073583f5f.png">
