### PR TITLE
Load environment variable definitions on runtime

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VUE_APP_OAPI=http://localhost:8999/pygeoapi
-VUE_APP_MQTT=mqtt://localhost:1883
-VUE_APP_WAF=http://localhost:8999/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:14.18.1 as ui-builder
- 
+
 RUN mkdir /usr/src/app
- 
+
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
- 
+
 COPY package.json /usr/src/app/package.json
 
 WORKDIR /usr/src/app
@@ -19,6 +19,9 @@ RUN npm run build && \
     rm -fr /usr/src/app
 
 FROM nginx
+COPY ./entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh
+
 COPY  --from=ui-builder /tmp/app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+env="
+window.VUE_APP_OAPI='${WIS2BOX_API_URL:-http://localhost:8999/pygeoapi}'\n
+window.VUE_APP_MQTT='${WIS2BOX_MQTT_URL:-mqtt://localhost:1883}'\n
+window.VUE_APP_WAF='${WIS2BOX_URL:-http://localhost:8999}/data/'\n
+"
+echo $env >> /usr/share/nginx/html/env.js

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,3 @@
+window.VUE_APP_OAPI="http://localhost:8999/pygeoapi"
+window.VUE_APP_MQTT="mqtt://localhost:1883"
+window.VUE_APP_WAF="http://localhost:8999/data/"

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
     <meta name="og:description" content="WIS 2.0 node in a box provides a platform with the capabilities for centres to integrate their data holdings and publish them to the WMO Information System with a plug and play capability supporting data publishing, discovery and access.">
     <meta property="og:image" content="<%= BASE_URL %>assets/img/logo.png">
     <link rel="stylesheet" href="<%= BASE_URL %>wis2box-ui.css">
+    <script src="<%= BASE_URL %>env.js" type="text/javascript"></script>
   </head>
   <body>
     <div id="wis2box-ui-app"></div>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -31,7 +31,7 @@
 <script>
 import { defineComponent } from "vue";
 
-let oapi = process.env.VUE_APP_OAPI;
+let oapi = window.VUE_APP_OAPI;
 
 export default defineComponent({
   name: "DataTable",

--- a/src/components/PlotterChart.vue
+++ b/src/components/PlotterChart.vue
@@ -22,7 +22,7 @@ import Plotly from "plotly.js-dist-min";
 import { defineComponent } from "vue";
 import { mdiDownload } from "@mdi/js";
 
-let oapi = process.env.VUE_APP_OAPI;
+let oapi = window.VUE_APP_OAPI;
 
 export default defineComponent({
   name: "PlotterChart",

--- a/src/components/PlotterDialog.vue
+++ b/src/components/PlotterDialog.vue
@@ -22,7 +22,7 @@
 import PlotterChart from "@/components/PlotterChart.vue";
 import PlotterNavigation from "@/components/PlotterNavigation.vue";
 import DataTable from "@/components/DataTable.vue";
-let oapi = process.env.VUE_APP_OAPI;
+let oapi = window.VUE_APP_OAPI;
 import { defineComponent } from "vue";
 
 export default defineComponent({

--- a/src/components/PlotterNavigation.vue
+++ b/src/components/PlotterNavigation.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-let oapi = process.env.VUE_APP_OAPI;
+let oapi = window.VUE_APP_OAPI;
 
 export default {
   name: "PlotterNavigation",

--- a/src/components/WisMap.vue
+++ b/src/components/WisMap.vue
@@ -33,7 +33,7 @@ import { circleMarker, geoJSON } from "leaflet/dist/leaflet-src.esm";
 import "leaflet/dist/leaflet.css";
 import { LMap, LTileLayer, LGeoJson } from "@vue-leaflet/vue-leaflet";
 
-let oapi = process.env.VUE_APP_OAPI;
+let oapi = window.VUE_APP_OAPI;
 import { defineComponent } from "vue";
 
 export default defineComponent({

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -1,10 +1,14 @@
 <template id="services">
-  <v-row v-for="(v, k) in services" justify="center" align="center" :key="k">
-    <v-col>{{ k }}</v-col>
-    <v-col
-      ><a :target="k" :title="k" :href="v">{{ v }}</a></v-col
-    >
-    <v-divider />
+  <v-row justify="center" align="center">
+    <v-card class="text-center" width="60%">
+      <v-row v-for="(v, k) in services" :key="k">
+        <v-col>{{ k }}</v-col>
+        <v-col
+          ><a :target="k" :title="k" :href="v">{{ v }}</a></v-col
+        >
+        <v-divider />
+      </v-row>
+    </v-card>
   </v-row>
 </template>
 
@@ -15,9 +19,9 @@ export default {
   data: function () {
     return {
       services: {
-        API: process.env.VUE_APP_OAPI,
-        MQTT: process.env.VUE_APP_MQTT,
-        WAF: process.env.VUE_APP_WAF
+        API: window.VUE_APP_OAPI,
+        MQTT: window.VUE_APP_MQTT,
+        WAF: window.VUE_APP_WAF,
       },
     };
   },


### PR DESCRIPTION
Addresses https://github.com/wmo-im/wis2box/issues/133
- Add entrypoint script to inject environment variables to a script block in `index.html`.
- Remove `.env` file
- Update source of URLs from `process.env...` to `window...` as created from the entrypoint script.

From adding the line ```WIS2BOX_MQTT_URL=mqtt://localhost:1885``` to `dev.env`:
![image](https://user-images.githubusercontent.com/40066515/157559630-761e88fd-957d-4b61-9fc9-70bbb7f27472.png)

