### PR TITLE
Cache Docker image in GitHub Actions

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/arm64, linux/amd64
           push: true
           tags: |


### PR DESCRIPTION
Speed up image build and publishing by caching the build using [GitHub Cache API](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache).