### PR TITLE
Improve navigation components

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,11 +3,13 @@
     <app-header app />
 
     <v-main>
-      <v-row justify="center">
-        <v-card flat width="80%" class="pt-4">
-          <router-view />
-        </v-card>
-      </v-row>
+      <v-card flat class="py-3">
+        <v-row justify="center">
+          <v-responsive width="90%" max-width="1130">
+            <router-view />
+          </v-responsive>
+        </v-row>
+      </v-card>
     </v-main>
 
     <app-footer app class="pt-4" />
@@ -15,15 +17,15 @@
 </template>
 
 <script>
-import AppHeader from "@/components/app/AppHeader.vue";
 import AppFooter from "@/components/app/AppFooter.vue";
+import AppHeader from "@/components/app/AppHeader.vue";
 
 import { useI18n } from "vue-i18n";
 
 export default {
   components: {
-    AppHeader,
     AppFooter,
+    AppHeader,
   },
   data() {
     return {

--- a/src/components/ChartDialog.vue
+++ b/src/components/ChartDialog.vue
@@ -6,9 +6,7 @@
           <v-toolbar>
             <v-toolbar-title v-text="station.properties.name" />
             <v-spacer />
-            <v-btn @click="$root.toggleDialog" icon>
-              <v-icon>mdiClose</v-icon>
-            </v-btn>
+            <v-btn @click="$root.toggleDialog" icon v-html="'X'" />
             <template v-slot:extension>
               <v-tabs v-model="selectedTab" color="#014e9e" grow>
                 <v-tab v-for="(item, i) in tabs" :value="i" :key="i">
@@ -49,8 +47,8 @@
                   </v-row>
                 </v-card>
               </div>
-              <div v-show="selectedTab === 2 || selectedTab === 3">
-                <data-viewer :choice="selectedTab" :station="station.id" />
+              <div v-show="selectedTab === 2">
+                <data-viewer :station="station" />
               </div>
             </v-card>
           </v-responsive>
@@ -77,7 +75,7 @@ export default defineComponent({
   data: function () {
     return {
       selectedTab: 0,
-      tabs: ["station.map", "station.properties", "chart.chart", "table.table"],
+      tabs: ["station.map", "station.properties", "navigation.data"],
       features_: this.features,
     };
   },

--- a/src/components/app/AppHeader.vue
+++ b/src/components/app/AppHeader.vue
@@ -9,21 +9,28 @@
       </template>
 
       <template v-slot:default>
-        <v-container fluid>
-          <v-row>
-            <v-spacer />
-            <select-locale class="pt-4 pr-4" />
-          </v-row>
-          <v-row fill-height>
-            <a :href="wis2" title="wis2box">
-              <img :src="logo" class="px-4 pb-6" />
-            </a>
-          </v-row>
-        </v-container>
+        <v-row justify="center">
+          <v-responsive width="90%" max-width="1130">
+            <v-container fluid>
+              <v-row>
+                <v-spacer />
+                <select-locale class="pt-4 pr-4" />
+              </v-row>
+              <v-row>
+                <a :href="wis2" title="wis2box">
+                  <img :src="logo" class="px-4 pb-6" />
+                </a>
+              </v-row>
+            </v-container>
+          </v-responsive>
+        </v-row>
       </template>
     </v-app-bar>
-
-    <app-nav class="py-2" />
+    <v-row justify="center">
+      <v-responsive width="90%" max-width="1130">
+        <app-nav />
+      </v-responsive>
+    </v-row>
   </div>
 </template>
 

--- a/src/components/app/AppNav.vue
+++ b/src/components/app/AppNav.vue
@@ -2,14 +2,14 @@
   <div class="app-nav">
     <v-app-bar flat>
       <template v-slot:prepend>
-        <v-btn-group divided>
+        <v-btn-toggle divided>
           <template v-for="(item, i) in items" :key="i">
             <v-hover v-slot="{ isHovering, props }">
               <v-btn
                 :href="item.href"
                 :to="item.target"
                 :target="`_window_${item.text}`"
-                :color="btnColor(isHovering)"
+                :color="isHovering ? '#014e9e' : undefined"
                 class="font-weight-bold"
                 variant="text"
                 v-bind="props"
@@ -18,7 +18,7 @@
               </v-btn>
             </v-hover>
           </template>
-        </v-btn-group>
+        </v-btn-toggle>
       </template>
     </v-app-bar>
   </div>
@@ -34,7 +34,6 @@ export default defineComponent({
   template: "#app-nav",
   data: function () {
     return {
-      documentation: documentation,
       items: [
         {
           text: "home",
@@ -44,7 +43,7 @@ export default defineComponent({
         {
           text: "datasets",
           target: "/datasets",
-          href: undefined
+          href: undefined,
         },
         {
           text: "services",
@@ -63,11 +62,6 @@ export default defineComponent({
         },
       ],
     };
-  },
-  methods: {
-    btnColor(isHovering) {
-      return isHovering ? "#014e9e" : undefined;
-    },
   },
 });
 </script>

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -2,17 +2,9 @@
   <div class="data-navigation">
     <v-navigation-drawer floating permanent color="#d5e3f0">
       <v-container>
-        <v-list-item-title class="text-h6 py-2" v-html="$t('chart.options')" />
-
-        <v-divider class="my-2" />
-
-        <v-list-item-subtitle v-html="$t('chart.collection')" />
         <v-menu>
           <template v-slot:activator="{ props }">
-            <v-list-item
-              class="font-weight-bold text-center py-3"
-              v-bind="props"
-            >
+            <v-list-item class="pa-2 text-h6 text-center" v-bind="props">
               {{ choices.collection.description || $t("chart.collection") }}
             </v-list-item>
           </template>
@@ -20,6 +12,7 @@
             <v-list-item
               v-for="(item, i) in choices.collections"
               :key="i"
+              :value="item.title"
               link
               @click="updateCollection(item)"
             >
@@ -31,26 +24,18 @@
         <v-divider class="my-2" />
 
         <v-list-item-subtitle v-html="$t('chart.observed_property')" />
-        <v-menu>
-          <template v-slot:activator="{ props }">
-            <v-list-item
-              class="font-weight-bold text-center py-3"
-              v-bind="props"
-            >
-              {{ choices.datastream.name || $t("chart.observed_property") }}
-            </v-list-item>
-          </template>
-          <v-list>
-            <v-list-item
-              v-for="(item, i) in choices.datastreams"
-              :key="i"
-              link
-              @click="updateData(item)"
-            >
-              <v-list-item-text v-html="$root.clean(item.name)" />
-            </v-list-item>
-          </v-list>
-        </v-menu>
+        <v-list-item-group v-model="model">
+          <v-list-item
+            v-for="(item, i) in choices.datastreams"
+            :key="i"
+            :value="i"
+            active-color="#014e9e"
+            link
+            @click="updateData(item)"
+          >
+            <v-list-item-text v-html="$root.clean(item.name)" />
+          </v-list-item>
+        </v-list-item-group>
       </v-container>
     </v-navigation-drawer>
   </div>
@@ -67,13 +52,13 @@ export default {
     return {
       choices_: this.choices,
       alert_: this.alert,
+      model: 1
     };
   },
   methods: {
     async updateCollection(newC) {
       this.choices_.collection = newC;
       const [station] = this.choices_.station;
-      console.log(station);
       var request_url = `${oapi}/collections/${newC.id}/items?f=json&sortby=-resultTime&wigos_station_identifier=${station}&properties=resultTime&limit=1`;
       var response = await fetch(request_url);
       var data = await response.json();

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -39,6 +39,15 @@ export default defineComponent({
   name: "DataTable",
   template: "#data-table",
   props: ["choices", "alert"],
+  mounted: function () {
+    this.$nextTick(() => {
+      if (this.choices_.collection !== "" && this.choices_.datastream !== "") {
+        for (var station of this.choices_.station) {
+          this.loadCollection(this.choices_.collection, station);
+        }
+      }
+    });
+  },
   watch: {
     choices: {
       handler(newValue) {

--- a/src/components/data/DataViewer.vue
+++ b/src/components/data/DataViewer.vue
@@ -1,14 +1,33 @@
 <template id="data-viewer">
   <div class="data-viewer">
-    <v-card>
-      <v-layout>
-        <data-navigation :choices="choices" :alert="alert" />
+    <v-layout>
+      <data-navigation :choices="choices" :station="station" :alert="alert" />
+      <v-row justify="center" fill-height>
         <v-main>
-            <data-plotter v-show="choice === 2" :choices="choices" :alert="alert" />
-            <data-table v-show="choice === 3" :choices="choices" :alert="alert" />
+          <v-toolbar color="#d5e3f0">
+            <v-spacer />
+            <v-tabs v-model="tab" end>
+              <v-tab
+                v-for="(item, i) in tabs"
+                class="text-center pa-2"
+                :value="i"
+                :key="i"
+              >
+                {{ $t(item) }}
+              </v-tab>
+            </v-tabs>
+          </v-toolbar>
+          <v-window v-model="tab">
+            <v-window-item :value="0">
+              <data-plotter :choices="choices" :alert="alert" />
+            </v-window-item>
+            <v-window-item :value="1">
+              <data-table :choices="choices" :alert="alert" />
+            </v-window-item>
+          </v-window>
         </v-main>
-      </v-layout>
-    </v-card>
+      </v-row>
+    </v-layout>
   </div>
 </template>
 
@@ -22,7 +41,7 @@ import { defineComponent } from "vue";
 export default defineComponent({
   name: "DataViewer",
   template: "#data-viewer",
-  props: ["station", "choice"],
+  props: ["station"],
   components: {
     DataPlotter,
     DataNavigation,
@@ -31,11 +50,13 @@ export default defineComponent({
   data() {
     return {
       drawer: true,
+      tab: 0,
+      tabs: ["chart.chart", "table.table"],
       choices: {
         collection: "",
         datastream: "",
         discovery_metadata: "",
-        station: new Set([this.station]),
+        station: new Set([this.station.id]),
         stations: [],
         collections: [],
         datastreams: [],
@@ -52,7 +73,7 @@ export default defineComponent({
     },
   },
   watch: {
-    choice: {
+    tab: {
       handler() {
         this.alert.value = false;
       },

--- a/src/components/leaflet/WisStation.vue
+++ b/src/components/leaflet/WisStation.vue
@@ -202,7 +202,6 @@ export default defineComponent({
       })
         .then(function (response) {
           // handle success
-          console.log(response.data);
           ret = response.data.features;
         })
         .catch(function (error) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,7 +28,7 @@
     "status": "Operating status"
   },
   "chart": {
-    "chart": "Chart",
+    "chart": "Plot",
     "options": "Options",
     "collection": "Collection",
     "observed_property": "Observed Property",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,15 +3,11 @@
     <chart-dialog :features="features" />
   </div>
   <div class="home" :style="{ opacity: $root.dialog ? '0' : '1' }">
-    <v-alert
-      border="start"
-      variant="contained-text"
-      color="#014e9e"
-    >
+    <v-alert border="start" variant="contained-text" color="#014e9e">
       <h2>{{ $t("messages.welcome") }}</h2>
     </v-alert>
 
-    <v-card>
+    <v-card flat>
       <wis-map :features="features" :params="{ limit: 25 }" />
     </v-card>
   </div>


### PR DESCRIPTION
- Better spacing for main app body. 
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/40066515/171767630-3ff4ade8-4805-4720-8196-b3cfcb5784d8.png">
- Cleanup data navigator.
- Merge chart and table tabs in station dialog.
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/40066515/171767830-a69520e5-22ed-41bf-9bee-eacbcc579b90.png">

re: https://github.com/wmo-im/wis2box/issues/188
- [x]  rename Chart tab to Data & combine Chart / Table