### PR TITLE
Update Data tab and time references

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,24 @@ export default {
         ).replaceAll("_", " ");
       }
     },
+    parseForNameAndTime(datastream) {
+      var name = datastream.name;
+      console.log(datastream);
+      if (datastream.phenomenonTime.includes("/")) {
+        const splitTime = datastream.phenomenonTime.split("/");
+        var startDate = new Date(splitTime[0]);
+        var endDate = new Date(splitTime[1]);
+        var timeDifference = endDate.getTime() - startDate.getTime();
+        var hourDifference = Math.floor(timeDifference / (1000 * 3600));
+        if (hourDifference > 0) {
+          name = `${name} (${hourDifference} hr)`;
+        } else {
+          var minuteDifference = Math.floor(timeDifference / (1000 * 60));
+          name = `${name} (${minuteDifference} min)`;
+        }
+      }
+      return this.clean(name);
+    },
   },
   setup() {
     const { t } = useI18n();

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -38,7 +38,7 @@
             class="text-left text-body-2"
             @click="updateData(item, i)"
           >
-            {{ $root.clean(item.name) }}
+            {{ parseForNameAndTime(item) }}
           </v-list-item>
           <v-divider
             class="pb-1 mx-2"
@@ -120,10 +120,29 @@ export default {
     updateData(newD, index) {
       this.choices_.datastream = {
         id: newD.name,
-        name: this.$root.clean(newD.name),
+        index: newD.index,
+        name: this.parseForNameAndTime(newD),
         units: newD.units,
       };
+
       this.model = index;
+    },
+    parseForNameAndTime(datastream) {
+      var name = datastream.name;
+      if (datastream.phenomenonTime.includes("/")) {
+        const splitTime = datastream.phenomenonTime.split("/");
+        var startDate = new Date(splitTime[0]);
+        var endDate = new Date(splitTime[1]);
+        var timeDifference = endDate.getTime() - startDate.getTime();
+        var hourDifference = Math.floor(timeDifference / (1000 * 3600));
+        if (hourDifference > 0){
+          name = `${name} (${hourDifference} hr)`;
+        } else {
+          var minuteDifference = Math.floor(timeDifference / (1000 * 60));
+          name = `${name} (${minuteDifference} min)`;
+        }
+      }
+      return this.$root.clean(name);
     },
   },
 };

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -38,7 +38,7 @@
             class="text-left text-body-2"
             @click="updateData(item, i)"
           >
-            {{ parseForNameAndTime(item) }}
+            {{ $root.parseForNameAndTime(item) }}
           </v-list-item>
           <v-divider
             class="pb-1 mx-2"
@@ -121,28 +121,10 @@ export default {
       this.choices_.datastream = {
         id: newD.name,
         index: newD.index,
-        name: this.parseForNameAndTime(newD),
+        name: this.$root.parseForNameAndTime(newD),
         units: newD.units,
       };
-
       this.model = index;
-    },
-    parseForNameAndTime(datastream) {
-      var name = datastream.name;
-      if (datastream.phenomenonTime.includes("/")) {
-        const splitTime = datastream.phenomenonTime.split("/");
-        var startDate = new Date(splitTime[0]);
-        var endDate = new Date(splitTime[1]);
-        var timeDifference = endDate.getTime() - startDate.getTime();
-        var hourDifference = Math.floor(timeDifference / (1000 * 3600));
-        if (hourDifference > 0){
-          name = `${name} (${hourDifference} hr)`;
-        } else {
-          var minuteDifference = Math.floor(timeDifference / (1000 * 60));
-          name = `${name} (${minuteDifference} min)`;
-        }
-      }
-      return this.$root.clean(name);
     },
   },
 };

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -1,40 +1,51 @@
 <template id="data-navigation">
   <div class="data-navigation">
-    <v-navigation-drawer floating permanent color="#d5e3f0">
-      <v-container>
-        <v-menu>
-          <template v-slot:activator="{ props }">
-            <v-list-item class="pa-2 text-h6 text-center" v-bind="props">
-              {{ choices.collection.description || $t("chart.collection") }}
-            </v-list-item>
-          </template>
-          <v-list>
-            <v-list-item
-              v-for="(item, i) in choices.collections"
-              :key="i"
-              :value="item.title"
-              link
-              @click="updateCollection(item)"
-            >
-              <v-list-item-title v-html="prepareCollection(item)" />
-            </v-list-item>
-          </v-list>
-        </v-menu>
+    <v-navigation-drawer permanent absolute color="#d5e3f0" class="text-center">
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-list-item class="pa-2 text-h6" v-bind="props">
+            {{ choices.collection.description || $t("chart.collection") }}
+          </v-list-item>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="(item, i) in choices.collections"
+            :key="i"
+            :value="item.title"
+            @click="updateCollection(item)"
+          >
+            <v-list-item-title v-html="$root.clean(item.title)" />
+          </v-list-item>
+        </v-list>
+      </v-menu>
 
-        <v-divider class="my-2" />
+      <v-divider />
 
-        <v-list-item-subtitle v-html="$t('chart.observed_property')" />
-        <v-list-item
+      <v-list-item-subtitle
+        class="mt-2"
+        v-html="$t('chart.observed_property')"
+      />
+      <v-list nav max-height="480px" bg-color="#d5e3f0">
+        <template
           v-for="(item, i) in choices.datastreams"
           :key="i"
-          :value="i"
-          active-color="#014e9e"
-          :active="model === i"
-          @click="updateData(item, i)"
+          class="mr-3"
         >
-          <v-list-item-text v-html="$root.clean(item.name)" />
-        </v-list-item>
-      </v-container>
+          <v-list-item
+            :value="i"
+            active-color="#014e9e"
+            :active="model === i"
+            class="text-left text-body-2"
+            @click="updateData(item, i)"
+          >
+            {{ $root.clean(item.name) }}
+          </v-list-item>
+          <v-divider
+            class="pb-1 mx-2"
+            v-if="i < choices.datastreams.length - 1"
+          />
+        </template>
+      </v-list>
     </v-navigation-drawer>
   </div>
 </template>
@@ -54,7 +65,7 @@ export default {
     };
   },
   watch: {
-    'choices.collections': {
+    "choices.collections": {
       handler(c) {
         if (this.station.links.length > 0) {
           for (const item of c) {
@@ -63,16 +74,11 @@ export default {
             }
           }
         }
-      }, deep: true
-    }
+      },
+      deep: true,
+    },
   },
   methods: {
-    prepareCollection(item) {
-      if (this.station.id === item.title) {
-        this.updateCollection(item);
-      }
-      return this.$root.clean(item.title);
-    },
     async updateCollection(newC) {
       this.choices_.collection = newC;
       var station = this.station.id;

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -53,6 +53,19 @@ export default {
       model: -1,
     };
   },
+  watch: {
+    'choices.collections': {
+      handler(c) {
+        if (this.station.links.length > 0) {
+          for (const item of c) {
+            if (this.station.links[0].title === item.id) {
+              this.updateCollection(item);
+            }
+          }
+        }
+      }, deep: true
+    }
+  },
   methods: {
     prepareCollection(item) {
       if (this.station.id === item.title) {

--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -70,6 +70,7 @@ export default defineComponent({
       },
       config: {
         modeBarButtonsToAdd: [],
+        modeBarButtonsToRemove: ["zoom2d", "pan2d", "select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d"],
       },
       font: { size: 14 },
       alert_: this.alert,
@@ -174,14 +175,16 @@ export default defineComponent({
           .then(function (response) {
             // handle success
             self.config.modeBarButtonsToAdd.push({
-              name: "Data Source " + station_id,
+              name: self.$t("chart.data_source") + " " + station_id,
               icon: {
                 width: 24,
                 height: 24,
                 path: mdiDownload,
               },
               click: function () {
-                window.location.href = response.request.responseURL;
+                const [start, end] = self.layout.xaxis.range;
+                var timeExtent = `${new Date(start + "Z").toISOString()}/${new Date(end + "Z").toISOString()}`
+                window.location.href = response.request.responseURL + `&datetime=${timeExtent}`;
               },
             });
             self.layout.yaxis.title = `${datastream.name} (${datastream.units})`;

--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -192,10 +192,9 @@ export default defineComponent({
               },
               click: function () {
                 const [start, end] = self.layout.xaxis.range;
-                var timeExtent = `
-                  ${new Date(`${start}Z`).toISOString()}/
-                  ${new Date(`${end}Z`).toISOString()}
-                `;
+                var timeExtent = `${new Date(
+                  start + "Z"
+                ).toISOString()}/${new Date(end + "Z").toISOString()}`;
                 window.location.href =
                   response.request.responseURL + `&datetime=${timeExtent}`;
               },

--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -70,7 +70,15 @@ export default defineComponent({
       },
       config: {
         modeBarButtonsToAdd: [],
-        modeBarButtonsToRemove: ["zoom2d", "pan2d", "select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d"],
+        modeBarButtonsToRemove: [
+          "zoom2d",
+          "pan2d",
+          "select2d",
+          "lasso2d",
+          "zoomIn2d",
+          "zoomOut2d",
+          "autoScale2d",
+        ],
       },
       font: { size: 14 },
       alert_: this.alert,
@@ -109,7 +117,7 @@ export default defineComponent({
       Trace.y = this.getCol(features, y);
       Trace.name = station_id;
       this.data.push(Trace);
-      this.setDateLayout(features[features.length - 1])
+      this.setDateLayout(features[features.length - 1]);
     },
     async loadCollection(collection, station_id) {
       this.loading = true;
@@ -119,7 +127,6 @@ export default defineComponent({
 
       this.alert_.msg =
         station_id + this.$t("messages.no_observations_in_collection") + title;
-      this.layout.title = title;
 
       await this.$http({
         method: "get",
@@ -127,6 +134,7 @@ export default defineComponent({
         params: {
           f: "json",
           name: datastream.id,
+          index: datastream.index,
           wigos_station_identifier: station_id,
           resulttype: "hits",
         },
@@ -167,6 +175,7 @@ export default defineComponent({
           params: {
             f: "json",
             name: datastream.id,
+            index: datastream.index,
             wigos_station_identifier: station_id,
             sortby: "-resultTime",
             limit: limit,
@@ -183,17 +192,22 @@ export default defineComponent({
               },
               click: function () {
                 const [start, end] = self.layout.xaxis.range;
-                var timeExtent = `${new Date(start + "Z").toISOString()}/${new Date(end + "Z").toISOString()}`
-                window.location.href = response.request.responseURL + `&datetime=${timeExtent}`;
+                var timeExtent = `
+                  ${new Date(`${start}Z`).toISOString()}/
+                  ${new Date(`${end}Z`).toISOString()}
+                `;
+                window.location.href =
+                  response.request.responseURL + `&datetime=${timeExtent}`;
               },
             });
-            self.layout.yaxis.title = `${datastream.name} (${datastream.units})`;
             self.newTrace(
               response.data.features,
               "resultTime",
               "value",
               station_id
             );
+            self.layout.yaxis.title = datastream.units;
+            self.layout.title = datastream.name;
             self.plot();
           })
           .catch(function (error) {
@@ -207,8 +221,12 @@ export default defineComponent({
       }
     },
     setDateLayout(f) {
-      var startTime = new Date(new Date(f.properties.resultTime).setUTCHours(0, 0, 0, 0)).toISOString();
-      var endTime = new Date(new Date().setUTCHours(23, 59, 59, 999)).toISOString();
+      var startTime = new Date(
+        new Date(f.properties.resultTime).setUTCHours(0, 0, 0, 0)
+      ).toISOString();
+      var endTime = new Date(
+        new Date().setUTCHours(23, 59, 59, 999)
+      ).toISOString();
       this.layout.xaxis.range = [startTime, endTime];
       this.layout.xaxis.rangeslider.range = [startTime, endTime];
     },

--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -108,19 +108,17 @@ export default defineComponent({
       Trace.y = this.getCol(features, y);
       Trace.name = station_id;
       this.data.push(Trace);
+      this.setDateLayout(features[features.length - 1])
     },
     async loadCollection(collection, station_id) {
       this.loading = true;
       var self = this;
-      const range = this.layout.xaxis.range;
       const title = collection.description;
       const datastream = this.choices_.datastream;
 
       this.alert_.msg =
         station_id + this.$t("messages.no_observations_in_collection") + title;
       this.layout.title = title;
-      this.layout.xaxis.range = range;
-      this.layout.xaxis.rangeslider = { range: range };
 
       await this.$http({
         method: "get",
@@ -204,6 +202,12 @@ export default defineComponent({
             console.log("done");
           });
       }
+    },
+    setDateLayout(f) {
+      var startTime = new Date(new Date(f.properties.resultTime).setUTCHours(0, 0, 0, 0)).toISOString();
+      var endTime = new Date(new Date().setUTCHours(23, 59, 59, 999)).toISOString();
+      this.layout.xaxis.range = [startTime, endTime];
+      this.layout.xaxis.rangeslider.range = [startTime, endTime];
     },
   },
 });

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -1,31 +1,24 @@
 <template id="data-table">
   <div class="data-table">
     <v-card min-height="600px" class="ma-4">
-      <v-table v-show="title !== ''">
-        <template v-slot:default>
-          <thead>
-            <tr>
-              <th class="text-center" v-html="$t('table.time')" />
-              <th class="text-center" v-html="title" />
-            </tr>
-          </thead>
-        </template>
-      </v-table>
-
       <v-alert v-show="alert.value" type="warning" v-html="alert.msg" />
 
-      <v-card id="scroll-target" class="overflow-y-auto" max-height="500">
-        <v-table v-scroll:#scroll-target="onScroll">
-          <template v-slot:default>
-            <tbody>
-              <tr v-for="(date, index) in data.time" :key="index">
-                <td v-html="formatDate(date)" />
-                <td v-html="data.value[index]" />
-              </tr>
-            </tbody>
-          </template>
-        </v-table>
-      </v-card>
+      <v-table v-show="title !== ''" fixed-header height="600px">
+        <thead>
+          <tr>
+            <th class="text-center" v-html="$t('table.result_time')" />
+            <th class="text-center" v-html="$t('table.phenomenon_time')" />
+            <th class="text-center" v-html="title" />
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(date, i) in data.time" :key="i">
+            <td v-html="date" />
+             <td v-html="data.phenomenonTime[i]" />
+            <td v-html="data.value[i]" />
+          </tr>
+        </tbody>
+      </v-table>
     </v-card>
   </div>
 </template>
@@ -79,9 +72,6 @@ export default defineComponent({
   methods: {
     onScroll(e) {
       this.headerOverflow = e.target.scrollTop;
-    },
-    formatDate(date) {
-      return new Date(date).toISOString();
     },
     getCol(features, key) {
       if (key.includes(".")) {
@@ -166,6 +156,10 @@ export default defineComponent({
             // handle success
             self.title = `${datastream.name} (${datastream.units})`;
             self.data.time = self.getCol(response.data.features, "resultTime");
+            self.data.phenomenonTime = self.getCol(
+              response.data.features,
+              "phenomenonTime"
+            );
             self.data.value = self.getCol(response.data.features, "value");
           })
           .catch(function (error) {

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -107,6 +107,7 @@ export default defineComponent({
         params: {
           f: "json",
           name: datastream.id,
+          index: datastream.index,
           wigos_station_identifier: station_id,
           resulttype: "hits",
         },
@@ -147,6 +148,7 @@ export default defineComponent({
           params: {
             f: "json",
             name: datastream.id,
+            index: datastream.index,
             wigos_station_identifier: station_id,
             sortby: "-resultTime",
             limit: limit,

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -1,6 +1,6 @@
 <template id="data-table">
   <div class="data-table">
-    <v-card min-height="600px" class="pa-2">
+    <v-card min-height="600px" class="ma-4">
       <v-table v-show="title !== ''">
         <template v-slot:default>
           <thead>
@@ -81,11 +81,7 @@ export default defineComponent({
       this.headerOverflow = e.target.scrollTop;
     },
     formatDate(date) {
-      return new Date(date).toLocaleString(this.$t("code"), {
-        timeZoneName: "short",
-        timeZone: "UTC",
-        hour12: false,
-      });
+      return new Date(date).toISOString();
     },
     getCol(features, key) {
       if (key.includes(".")) {

--- a/src/components/leaflet/WisStation.vue
+++ b/src/components/leaflet/WisStation.vue
@@ -219,7 +219,7 @@ export default defineComponent({
 
 <style>
 tr:nth-child(even) {
-  background-color: #d5e3f0;
+  background-color: #eeeeee;
 }
 th,
 td {

--- a/src/components/leaflet/WisStation.vue
+++ b/src/components/leaflet/WisStation.vue
@@ -155,7 +155,10 @@ export default defineComponent({
                     <h2> ${feature.properties.name} </h2>
                     <h5>
                       ${self.$t("messages.from")}
-                      ${new Date(resultTime).toUTCString()}
+                      ${new Date(resultTime).toLocaleString(self.$t("code"), {
+                        timeZone: "UTC",
+                        hour12: false,
+                      })}
                     </h5>
                     <table>
                       ${tableContent}

--- a/src/components/leaflet/WisStation.vue
+++ b/src/components/leaflet/WisStation.vue
@@ -145,7 +145,7 @@ export default defineComponent({
                   var props = item.properties;
                   tableContent += `
                     <tr>
-                      <th> ${self.$root.clean(props.name)} </th>
+                      <th> ${self.$root.parseForNameAndTime(props)} </th>
                       <td> ${props.value} ${props.units} </td>
                     </tr>
                   `;

--- a/src/locales/_template.json
+++ b/src/locales/_template.json
@@ -31,7 +31,8 @@
     "options": "",
     "collection": "",
     "observed_property'": "",
-    "station": ""
+    "station": "",
+    "data_source": ""
   },
   "table": {
     "table": "",

--- a/src/locales/_template.json
+++ b/src/locales/_template.json
@@ -36,7 +36,8 @@
   },
   "table": {
     "table": "",
-    "time": ""
+    "result_time": "",
+    "phenomenon_time": ""
   },
   "datasets": {
     "topic": ""

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,11 +32,12 @@
     "options": "Options",
     "collection": "Collection",
     "observed_property": "Observed Property",
-    "station": "Stations"
+    "station": "Stations",
+    "data_source": "Data source"
   },
   "table": {
     "table": "Table",
-    "time": "Phenomenon Time"
+    "time": "Result Time"
   },
   "datasets": {
     "topic": "Topic"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,8 @@
   },
   "table": {
     "table": "Table",
-    "time": "Result Time"
+    "result_time": "Result time",
+    "phenomenon_time": "Phenomenon time"
   },
   "datasets": {
     "topic": "Topic"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -37,7 +37,8 @@
   },
   "table": {
     "table": "Tabla",
-    "time": "Tiempo de resulto"
+    "result_time": "Tiempo de resulto",
+    "phenomenon_time": "Tiempo de fenómeno"
   },
   "datasets": {
     "topic": "Tema"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -32,11 +32,12 @@
     "options": "Opciones",
     "collection": "Colección",
     "observed_property": "Propiedad observada",
-    "station": "Estación"
+    "station": "Estación",
+    "data_source": "Fuente de datos"
   },
   "table": {
     "table": "Tabla",
-    "time": "Tiempo de fenómeno"
+    "time": "Tiempo de resulto"
   },
   "datasets": {
     "topic": "Tema"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -37,7 +37,8 @@
   },
   "table": {
     "table": "Tableau",
-    "time": "Temps de résultat"
+    "result_time": "Temps de résultat",
+    "phenomenon_time": "Temps du phénomène"
   },
   "datasets": {
     "topic": "Sujet"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -32,11 +32,12 @@
     "options": "Choix",
     "collection": "Collection",
     "observed_property": "Propriété observée",
-    "station": "Station"
+    "station": "Station",
+    "data_source": "Source de données"
   },
   "table": {
     "table": "Tableau",
-    "time": "Heure du phénomène"
+    "time": "Temps de résultat"
   },
   "datasets": {
     "topic": "Sujet"


### PR DESCRIPTION
- [x]  date range of the plotly graph should always end at the end of the current day. 
- [x]  remove the selection tools/buttons from the plotly graph.

Plot date range extends from the Z0 on date of earliest observation and extends to end of the current day. The data source button includes the temporal extent currently viewed on the plot (ex. ...&datetime=2021-11-18T09:54:59.999Z/2021-11-18T09:55:00.001Z). Default buttons have been pruned down.
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/40066515/171945770-29f1a489-f832-40bf-bd63-2c374cced2bb.png">

- [x]  select collection option should only show one (and then maybe if there is more than one it could be selectable). 

When a station has links to a collection, it is automatically selected in the data tab.
<img width="1464" alt="image" src="https://user-images.githubusercontent.com/40066515/171945686-1c4bbfed-7588-45d6-99d2-8adfbc23b285.png">

- Data table now includes phenomenonTime and resultTime as well as translations for each both in ISO format.
- Observations over a temporal extent have the hour or minute extent of the observation in the data navigator. Additionally queries filter by observedProperty name & index to ensure common measurement. 
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/40066515/171947929-377df13f-e993-433d-8837-09f56a68a57b.png">

- Use locale specific time. Include the time in names of observed properties with a temporal extent.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/40066515/171951283-20013f36-574e-4448-80eb-5e6672d167f6.png">
