### PR TITLE
Add dataset specific map

### DIFF
--- a/src/components/app/AppNav.vue
+++ b/src/components/app/AppNav.vue
@@ -41,11 +41,6 @@ export default defineComponent({
           href: undefined,
         },
         {
-          text: "map",
-          target: "/map",
-          href: undefined,
-        },
-        {
           text: "services",
           target: "/data-services",
           href: undefined,

--- a/src/components/leaflet/DatasetMap.vue
+++ b/src/components/leaflet/DatasetMap.vue
@@ -9,9 +9,8 @@
     >
       <l-map
         :ref="dataset.id"
-        :zoom="zoom"
         :center="center"
-        :options="{ zoomControl: false }"
+        :options="options"
         style="height: 160px; width: 256px"
         @ready="onReady()"
       >
@@ -24,7 +23,7 @@
 
 <script>
 import "leaflet/dist/leaflet.css";
-import { latLngBounds } from "leaflet/dist/leaflet-src.esm";
+import { geoJSON } from "leaflet/dist/leaflet-src.esm";
 import { LMap, LTileLayer, LGeoJson } from "@vue-leaflet/vue-leaflet";
 
 export default {
@@ -39,8 +38,13 @@ export default {
   data: function () {
     return {
       loading: false,
-      zoom: 0,
       center: [0, 0],
+      options: {
+        zoomControl: false,
+        doubleClickZoom: false,
+        dragging: false,
+        zoomSnap: 0.25,
+      },
       attribution:
         '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
       url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
@@ -48,22 +52,15 @@ export default {
   },
   methods: {
     onReady() {
+      this.loading = true;
       this.$nextTick(() => {
         this.map = this.$refs[this.dataset.id]["leafletObject"];
-        this.loadDataset();
+        this.map.fitBounds(geoJSON(this.dataset).getBounds());
+        this.map.zoomOut(0.25);
+        this.map.setMinZoom(this.map.getZoom());
+        this.map.setMaxZoom(this.map.getZoom());
+        this.loading = false;
       });
-    },
-    async loadDataset() {
-      this.loading = true;
-      let [x1, y1, x2, y2] = this.dataset.bbox;
-
-      this.center = [(y2 + y1) / 2, (x2 + x1) / 2];
-      var bounds = latLngBounds([
-        [x1, y1],
-        [x2, y2],
-      ]);
-      this.map.fitBounds(bounds);
-      this.loading = false;
     },
   },
 };

--- a/src/components/leaflet/StationInfo.vue
+++ b/src/components/leaflet/StationInfo.vue
@@ -1,35 +1,43 @@
 <template id="station-info">
   <div class="station-info">
-    <v-navigation-drawer permanent :width="station === null ? 255 : 510">
-      <v-menu>
-        <template v-slot:activator="{ props }">
-          <v-list-item class="pa-2 text-h6 text-center" v-bind="props">
-            {{ station_name || $t("chart.station") }}
-          </v-list-item>
-        </template>
+    <v-navigation-drawer permanent :width="station === null ? 300 : 600">
+      <v-toolbar>
+        <v-toolbar-title>
+          {{ station_name || $t("chart.station") }}
+        </v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          color="pink"
+          icon
+          v-show="station !== null"
+          @click="features_.station = null"
+        >
+          X
+        </v-btn>
+      </v-toolbar>
+      <v-divider />
+      <v-card flat class="text-center" v-show="station === null">
         <v-list>
-          <v-list-item
-            v-for="(station, i) in features_.stations.features"
-            :key="i"
-            @click="onClick(station)"
-          >
-            <v-list-item-title v-html="$root.clean(station.properties.name)" />
-            <v-spacer />
-            <a
-              :target="station.id"
-              :title="station.id"
-              :href="station.properties.url"
-            >
-              <h5 class="text-right">({{$t("station.report")}})</h5>
-            </a>
+          <v-list-item v-for="(s, i) in stations" :key="i" @click="onClick(s)">
+            <v-list-item-title v-html="$root.clean(s.properties.name)" />
+            <template v-slot:append>
+              <v-btn
+                variant="outlined"
+                size="small"
+                color="#014e9e"
+                :target="s.id"
+                :title="s.id"
+                :href="s.properties.url"
+              >
+                {{ $t("station.report") }}
+              </v-btn>
+            </template>
           </v-list-item>
         </v-list>
-      </v-menu>
+      </v-card>
 
-      <v-divider />
-
-      <v-card width="95%" flat class="text-center" v-show="station !== null">
-        <v-tabs v-model="tab" color="#014e9e">
+      <v-card flat v-show="station !== null">
+        <v-tabs density="compact" v-model="tab" color="#014e9e">
           <v-tab v-for="(item, i) in tabs" :value="i" :key="i">
             {{ $t(item) }}
           </v-tab>
@@ -53,9 +61,9 @@
             </v-table>
           </v-window-item>
           <v-window-item :value="1" eager>
-            <v-card class="text-center">
+            <v-row justify="center">
               <div id="stationStatus" />
-            </v-card>
+            </v-row>
           </v-window-item>
         </v-window>
       </v-card>
@@ -106,6 +114,11 @@ export default defineComponent({
       } else {
         return this.station;
       }
+    },
+    stations: function () {
+      var s = this.features.stations === null ? [] : this.features.stations.features;
+      console.log(s);
+      return s;
     },
   },
   watch: {

--- a/src/components/leaflet/WisMap.vue
+++ b/src/components/leaflet/WisMap.vue
@@ -28,7 +28,7 @@
                     <v-card width="95px" max-height="40px">
                       <v-select
                         v-model="limit_"
-                        :items="[10, 25, 50, numberMatched]"
+                        :items="items"
                         :label="$t('station.limit')"
                         hide-details
                         density="compact"
@@ -69,7 +69,7 @@ export default defineComponent({
   data: function () {
     return {
       numberMatched: 0,
-      limit_: 500,
+      limit_: null,
       loading: true,
       map: undefined,
       features_: this.features,
@@ -86,6 +86,18 @@ export default defineComponent({
         f: "json",
         limit: this.limit_,
       };
+    },
+    items: function () {
+      const opts = [10, 25, 50, 100];
+      const items = new Set();
+
+      for (const item of opts) {
+        if (item < this.numberMatched) {
+          items.add(item);
+        }
+      }
+      items.add(this.numberMatched);
+      return items;
     },
   },
   watch: {

--- a/src/components/leaflet/WisStation.vue
+++ b/src/components/leaflet/WisStation.vue
@@ -142,7 +142,7 @@ export default defineComponent({
 
 <style>
 tr:nth-child(even) {
-  background-color: #eeeeee;
+  background-color: #d5e3f0;
 }
 th,
 td {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,7 +5,8 @@ import Services from "../views/Services.vue";
 
 const routes = [
   {
-    path: "/map",
+    path: "/map/:topic",
+    props: true,
     name: "Map",
     component: Map,
   },

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -9,6 +9,32 @@
           <tbody>
             <tr class="pa-2 my-4" v-for="(item, i) in datasets" :key="i">
               <th>
+                <v-hover v-slot="{ isHovering, props }">
+                  <v-container>
+                    <v-row justify="center" fill-height>
+                      <v-card
+                        class="pa-2 ma-0"
+                        :elevation="isHovering ? 12 : 0"
+                        v-bind="props"
+                        @click="loadMap(item.id)"
+                      >
+                        <v-overlay
+                          open-on-hover
+                          contained
+                          activator="parent"
+                          class="align-center justify-center"
+                        >
+                          <v-btn flat>
+                            {{ $t("navigation.map") }}
+                          </v-btn>
+                        </v-overlay>
+                        <dataset-map :dataset="item" />
+                      </v-card>
+                    </v-row>
+                  </v-container>
+                </v-hover>
+              </th>
+              <td>
                 <v-btn
                   variant="text"
                   class="font-weight-bold"
@@ -19,30 +45,25 @@
                 >
                   {{ item.properties.title }}
                 </v-btn>
-                <v-container>
-                  <v-row justify="center" fill-height>
-                    <dataset-map :dataset="item" />
-                  </v-row>
-                </v-container>
-              </th>
-              <td>
-                <v-col cols="12" class="text-left">
-                  <p class="font-weight-bold">
-                    {{ $t("datasets.topic") + " : " }}
-                  </p>
-                  <code>{{ item.id }}</code>
+                <v-col cols="12" class="text-center">
+                  <span>
+                    <strong>{{ $t("datasets.topic") + " : " }}</strong>
+                    <code>{{ item.id }}</code>
+                  </span>
                 </v-col>
-                <v-btn-group variant="outlined" divided>
-                  <v-btn
-                    v-for="(item, i) in item.links"
-                    :key="i"
-                    :title="item.type"
-                    :href="item.href"
-                    :target="`_window_${item.type}`"
-                  >
-                    {{ $t(`datasets.${item.msg}`) }}
-                  </v-btn>
-                </v-btn-group>
+                <v-col cols="12" class="text-center">
+                  <v-btn-group variant="outlined" divided>
+                    <v-btn
+                      v-for="(item, i) in item.links"
+                      :key="i"
+                      :title="item.type"
+                      :href="item.href"
+                      :target="`_window_${item.type}`"
+                    >
+                      {{ $t(`datasets.${item.msg}`) }}
+                    </v-btn>
+                  </v-btn-group>
+                </v-col>
               </td>
             </tr>
           </tbody>
@@ -95,6 +116,12 @@ export default {
       c.links = links;
       this.datasets.push(c);
     }
+  },
+  methods: {
+    loadMap(topic) {
+      console.log(topic);
+      this.$router.push(`/map/${topic}`)
+    },
   },
 };
 </script>

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -4,7 +4,7 @@
   </div>
   <div class="map" :style="{ opacity: $root.dialog ? '0' : '1' }">
     <v-card flat>
-      <wis-map :features="features" :params="{ limit: 25 }" />
+      <wis-map :features="features" :params="{ topic: topic }" />
     </v-card>
   </div>
 </template>
@@ -20,6 +20,7 @@ export default {
     ChartDialog,
     WisMap,
   },
+  props: ["topic"],
   data: function () {
     return {
       features: {


### PR DESCRIPTION
- Replace map tab with dataset specific tab. Access by clicking on map from datasets/homepage.
- Show station list in nav bar when no station selected. Select station from list or by hovering on map.
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/40066515/185928879-83bb04b6-01c9-4084-a853-19e41d7f994e.png">
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/40066515/185928927-79762839-cc35-4770-9924-8122bb71e11d.png">
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/40066515/185928981-bd5c1a09-2d3a-4d8a-8b0b-058e7f9f3391.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/40066515/185929272-c28110b4-d48b-4855-872b-1280cb4f65cc.png">

