### PR TITLE
Split station tabs

### DIFF
--- a/src/components/station/StationHistory.vue
+++ b/src/components/station/StationHistory.vue
@@ -1,0 +1,159 @@
+<template id="station-history">
+  <div class="station-history">
+    <v-row justify="center">
+      <div id="stationHistory" />
+    </v-row>
+  </div>
+</template>
+
+<script>
+import Plotly from "plotly.js-dist-min";
+
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "StationHistory",
+  template: "#station-history",
+  props: ["features", "map"],
+  data() {
+    return {
+      features_: this.features,
+      data: [],
+      layout: {
+        height: 300,
+        width: 450,
+        showlegend: false,
+        xaxis: {
+          type: "date",
+          dtick: 86400000.0,
+          showgrid: true,
+          gridcolor: "#d5e3f0",
+          gridwidth: 2,
+        },
+        yaxis: {
+          autorange: true,
+          showgrid: false,
+          zeroline: false,
+          showline: false,
+          autotick: true,
+          ticks: "",
+          showticklabels: false,
+        },
+      },
+      config: {
+        displayModeBar: false,
+        responsive: true,
+      },
+    };
+  },
+  watch: {
+    "features_.station": {
+      async handler(station) {
+        if (station.links.length === 0) {
+          this.msg = `
+            ${this.$root.clean(station.properties.name)} ${this.$t(
+            "messages.no_linked_collections"
+          )}. ${this.$t("messages.how_to_link_station")}`;
+          this.snackbar = true;
+          this.loading = false;
+          this.tab = null;
+        } else {
+          this.loadObservations(station);
+        }
+      },
+    },
+  },
+  methods: {
+    plot() {
+      var plot = document.getElementById("stationHistory");
+      Plotly.purge(plot);
+      Plotly.newPlot(plot, this.data, this.layout, this.config);
+      this.loading = false;
+    },
+    async loadObservations(station) {
+      var self = this;
+      this.data = [];
+      await this.$http({
+        method: "get",
+        url: station.links[0].href + "/items",
+        params: {
+          f: "json",
+          sortby: "+resultTime",
+          wigos_station_identifier: station.id,
+          limit: 1,
+        },
+      })
+        .then(function (response) {
+          // handle success
+          self.oldestResultTime =
+            response.data.features[0].properties.resultTime;
+          var index = response.data.features[0].properties.index;
+          self.loadDailyObservations(station, index);
+        })
+        .catch(function (error) {
+          // handle error
+          console.log(error);
+          if (error.response.status === 401) {
+            self.msg = self.$t("messages.not_authorized");
+            self.snackbar = true;
+          }
+        })
+        .then(function () {
+          self.tab = 0;
+          self.loading = false;
+          console.log("done");
+        });
+    },
+    async loadDailyObservations(station, index) {
+      this.loading = true;
+      var now = new Date();
+      var then = new Date(this.oldestResultTime);
+      this.layout.xaxis.range = [then.toISOString(), now.toISOString()];
+      var self = this;
+      for (
+        var d = new Date(this.oldestResultTime);
+        d <= now;
+        d.setDate(d.getDate() + 1)
+      ) {
+        var date_ = d.toISOString().split("T")[0];
+        await this.$http({
+          method: "get",
+          url: station.links[0].href + "/items",
+          params: {
+            f: "json",
+            datetime: date_,
+            index: index,
+            wigos_station_identifier: station.id,
+          },
+        }).then(function (response) {
+          // handle success
+          let fillColor;
+          let hits = response.data.numberMatched;
+          if (hits === 0) {
+            fillColor = "#000000";
+          } else if (hits <= 7) {
+            fillColor = "#FF3300";
+          } else if (hits <= 19) {
+            fillColor = "#FF9900";
+          } else if (hits <= 24) {
+            fillColor = "#009900";
+          }
+          var trace = {
+            x: response.data.features.map((obs) => obs.properties.resultTime),
+            type: "histogram",
+            marker: {
+              color: fillColor,
+            },
+            xbins: {
+              size: 3600000,
+            },
+            name: date_,
+          };
+          self.data.push(trace);
+          self.plot();
+        });
+      }
+    },
+  },
+});
+</script>

--- a/src/components/station/StationInfo.vue
+++ b/src/components/station/StationInfo.vue
@@ -12,7 +12,7 @@
           v-show="station !== null"
           @click="features_.station = null"
         >
-          X
+          <v-icon icon="mdi-close"></v-icon>
         </v-btn>
       </v-toolbar>
       <v-divider />

--- a/src/components/station/StationLatest.vue
+++ b/src/components/station/StationLatest.vue
@@ -1,0 +1,112 @@
+<template id="station-status">
+  <div class="station-status">
+    <h5 class="text-left">
+      {{ $t("messages.from") + " " + latestResultTime }}
+    </h5>
+    <v-table>
+      <table>
+        <tr v-for="(item, i) in recentObservations" :key="i">
+          <th width="50%">{{ $root.parseForNameAndTime(item) }}</th>
+          <td width="50%">{{ item.value + " " + item.units }}</td>
+        </tr>
+      </table>
+    </v-table>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "StationLatest",
+  template: "#station-latest",
+  props: ["features", "map"],
+  data() {
+    return {
+      features_: this.features,
+      recentObservations: [],
+      latestResultTime: null,
+    };
+  },
+  watch: {
+    "features_.station": {
+      async handler(station) {
+        if (station.links.length === 0) {
+          this.msg = `
+            ${this.$root.clean(station.properties.name)} ${this.$t(
+            "messages.no_linked_collections"
+          )}. ${this.$t("messages.how_to_link_station")}`;
+          this.snackbar = true;
+          this.loading = false;
+          this.tab = null;
+        } else {
+          this.loadObservations(station);
+        }
+      },
+    },
+  },
+  methods: {
+    async loadObservations(station) {
+      var self = this;
+      await this.$http({
+        method: "get",
+        url: station.links[0].href + "/items",
+        params: {
+          f: "json",
+          sortby: "-resultTime",
+          wigos_station_identifier: station.id,
+          limit: 1,
+        },
+      })
+        .then(function (response) {
+          // handle success
+          self.latestResultTime =
+            response.data.features[0].properties.resultTime;
+          self.loadRecentObservations(station, response.data.numberMatched);
+        })
+        .catch(function (error) {
+          // handle error
+          console.log(error);
+          if (error.response.status === 401) {
+            self.msg = self.$t("messages.not_authorized");
+            self.snackbar = true;
+          }
+        })
+        .then(function () {
+          self.tab = 0;
+          self.loading = false;
+          console.log("done");
+        });
+    },
+    async loadRecentObservations(station, limit) {
+      this.loading = true;
+      var self = this;
+      await this.$http({
+        method: "get",
+        url: station.links[0].href + "/items",
+        params: {
+          f: "json",
+          datetime: `${self.latestResultTime}/..`,
+          wigos_station_identifier: station.id,
+          limit: limit,
+        },
+      }).then(function (response) {
+        // handle success
+        self.recentObservations = response.data.features.map(
+          (obs) => obs.properties
+        );
+      });
+    },
+  },
+});
+</script>
+
+<style scoped>
+tr:nth-child(odd) {
+  background-color: #eeeeee;
+}
+th,
+td {
+  padding: 8px;
+}
+</style>

--- a/src/components/station/StationStatus.vue
+++ b/src/components/station/StationStatus.vue
@@ -18,8 +18,8 @@
       <v-snackbar v-model="snackbar">
         {{ msg }}
         <template v-slot:actions>
-          <v-btn color="pink" variant="text" @click="snackbar = false">
-            X
+          <v-btn color="pink" @click="snackbar = false">
+            <v-icon icon="mdi-close"></v-icon>
           </v-btn>
         </template>
       </v-snackbar>
@@ -28,7 +28,6 @@
 </template>
 
 <script>
-
 import { defineComponent } from "vue";
 import StationHistory from "./StationHistory.vue";
 import StationLatest from "./StationLatest.vue";


### PR DESCRIPTION
- Split station tabs into their own components
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/40066515/191236876-6b944981-eb03-40f8-9a86-e8d818926c7f.png">


- History tab now shows all observations from a station, with the color corresponding to the number of observations received on the calendar day.
<img width="1498" alt="Screen Shot 2022-09-20 at 6 35 04 AM" src="https://user-images.githubusercontent.com/40066515/191236798-a023f0f7-5d2d-4985-b6a0-ad4405e7ae90.png">
<img width="1493" alt="Screen Shot 2022-09-20 at 6 34 48 AM" src="https://user-images.githubusercontent.com/40066515/191236736-63fde29a-f726-43aa-8a40-1d1e088bd5a7.png">
