### PR TITLE
Improve Loaders

### DIFF
--- a/src/components/leaflet/DatasetMap.vue
+++ b/src/components/leaflet/DatasetMap.vue
@@ -1,12 +1,9 @@
 <template id="dataset-map">
   <div class="dataset-map">
-    <div :style="{ visibility: loading ? 'visible' : 'hidden' }">
+    <div v-if="loading">
       <v-progress-linear striped indeterminate color="primary" />
     </div>
-    <div
-      :style="{ visibility: !loading ? 'visible' : 'hidden' }"
-      class="text-center"
-    >
+    <div v-show="!loading">
       <l-map
         :ref="dataset.id"
         :center="center"

--- a/src/components/leaflet/WisMap.vue
+++ b/src/components/leaflet/WisMap.vue
@@ -1,6 +1,6 @@
 <template id="wis-map">
   <div class="wis-map">
-    <div :style="{ visibility: loading ? 'visible' : 'hidden' }">
+    <div v-if="loading || vals.loading">
       <v-progress-linear striped indeterminate color="primary" />
     </div>
     <div
@@ -22,19 +22,8 @@
                   style="height: 60vh"
                   @ready="onReady()"
                 >
-                  <wis-station :features="features" :map="map" />
+                  <wis-station :vals="vals" :features="features" :map="map" />
                   <l-tile-layer :url="url" :attribution="attribution" />
-                  <l-control position="bottomleft">
-                    <v-card width="95px" max-height="40px">
-                      <v-select
-                        v-model="limit_"
-                        :items="items"
-                        :label="$t('station.limit')"
-                        hide-details
-                        density="compact"
-                      />
-                    </v-card>
-                  </l-control>
                   <l-control position="bottomright">
                     <v-card width="125px" class="legend pa-2">
                       <strong> {{ $t("messages.no_of_observations") }} </strong>
@@ -89,6 +78,9 @@ export default defineComponent({
     return {
       numberMatched: 0,
       limit_: null,
+      vals: {
+        loading: true,
+      },
       loading: true,
       map: undefined,
       features_: this.features,
@@ -134,13 +126,6 @@ export default defineComponent({
       }
       items.add(this.numberMatched);
       return items;
-    },
-  },
-  watch: {
-    limit_: {
-      handler() {
-        this.loadStations();
-      },
     },
   },
   methods: {

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -13,8 +13,8 @@
                   <v-container>
                     <v-row justify="center" fill-height>
                       <v-card
-                        class="pa-2 ma-0"
-                        :elevation="isHovering ? 12 : 0"
+                        class="pa-0 ma-0"
+                        :elevation="isHovering ? 24 : 0"
                         v-bind="props"
                         @click="loadMap(item.id)"
                       >


### PR DESCRIPTION
- [Show loading bar when station color is updating](https://github.com/wmo-im/wis2box-ui/commit/a2982d7ad8fbc3ac988edc5833a1425cc612c283)
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/40066515/192895994-f7ceb592-321a-48ed-a5ba-d28998909513.png">

- [Cleanup station history loading](https://github.com/wmo-im/wis2box-ui/commit/c7d2a59420c043b0f9b283f8e5e81675b810b463)
- Iterate better over long gaps / different months and years
- Do not count observations on days where there are none
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/40066515/192896155-230f782a-2fbf-4bc5-8bd5-f5ade1b327eb.png">

- Remove loader from dataset view after loading
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/40066515/192896423-2d1f7c10-07fa-4118-8ca7-fe87fad048fb.png">
