### PR TITLE
Set public path to working directory

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,7 @@ env="
 window.VUE_APP_URL='${WIS2BOX_URL}'\n
 window.VUE_APP_OAPI='${WIS2BOX_API_URL}'\n
 window.VUE_APP_MQTT='${WIS2BOX_MQTT_URL}'\n
-window.VUE_APP_WAF='${WIS2BOX_URL}'\n
+window.VUE_APP_WAF='${WIS2BOX_URL}/data/'\n
 window.VUE_APP_BASEMAP_URL='${WIS2BOX_BASEMAP_URL:-https://\{s\}.tile.openstreetmap.org/\{z\}/\{x\}/\{y\}.png}'\n
 window.VUE_APP_BASEMAP_ATTRIBUTION='${WIS2BOX_BASEMAP_ATTRIBUTION:-&copy; <a href=\"https://osm.org/copyright\">OpenStreetMap</a> contributors}'\n
 "

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,8 +65,6 @@ export default {
     },
   },
   setup() {
-    console.log(process.env.BASE_URL);
-    console.log(window.VUE_APP_URL);
     const { t } = useI18n();
     return {
       t,

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,8 @@
-module.exports = {
+const { defineConfig } = require('@vue/cli-service')
+
+module.exports = defineConfig({
+  publicPath:  "",
+
   transpileDependencies: ["vuetify"],
 
   pluginOptions: {
@@ -6,4 +10,4 @@ module.exports = {
       // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vuetify-loader
     },
   },
-};
+});


### PR DESCRIPTION
- Set public path to working directory for proxying wis2box-ui

Using default `WIS2BOX_API_URL` and `WIS2BOX_URL`
<img width="1504" alt="image" src="https://user-images.githubusercontent.com/40066515/195661286-dd1094c8-54ed-438a-8494-610d62e77e15.png">

Using `WIS2BOX_API_URL=http://localhost:6969/australia/oapi` and `WIS2BOX_URL=http://localhost:6969/australia` proxying wis2box from nginx listening to port 6969
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/40066515/195661787-b2e463f6-2a3c-421d-8d8a-7824b3490ca3.png">
