### PR TITLE
Make wis2box-ui mobile-friendlier

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -8,7 +8,7 @@ name: publish image to ghcr.io
 on:
   push:
     branches:
-      - main
+      - dev-1
   release:
     types: [published]
 
@@ -51,6 +51,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=test
             type=semver,pattern={{version}}
 
       - name: Build and push

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -8,7 +8,7 @@ name: publish image to ghcr.io
 on:
   push:
     branches:
-      - dev-1
+      - main
   release:
     types: [published]
 
@@ -51,7 +51,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=test
             type=semver,pattern={{version}}
 
       - name: Build and push

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,30 +39,6 @@ export default {
     toggleDialog: function () {
       this.dialog = this.dialog === true ? false : true;
     },
-    clean(word) {
-      if (typeof word === "string") {
-        return (
-          word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-        ).replaceAll("_", " ");
-      }
-    },
-    parseForNameAndTime(datastream) {
-      var name = datastream.name;
-      if (datastream.phenomenonTime.includes("/")) {
-        const splitTime = datastream.phenomenonTime.split("/");
-        var startDate = new Date(splitTime[0]);
-        var endDate = new Date(splitTime[1]);
-        var timeDifference = endDate.getTime() - startDate.getTime();
-        var hourDifference = Math.floor(timeDifference / (1000 * 3600));
-        if (hourDifference > 0) {
-          name = `${name} (${hourDifference} hr)`;
-        } else {
-          var minuteDifference = Math.floor(timeDifference / (1000 * 60));
-          name = `${name} (${minuteDifference} min)`;
-        }
-      }
-      return this.clean(name);
-    },
   },
   setup() {
     const { t } = useI18n();

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,14 +3,18 @@
     <app-header app />
 
     <v-main>
-      <v-card flat class="py-3">
+      <v-responsive class="pa-2">
         <v-row justify="center">
-          <v-responsive width="90%" max-width="1130">
-            <app-nav />
-            <router-view />
-          </v-responsive>
+          <v-card flat width="90%" max-width="1130">
+            <v-layout>
+              <app-nav />
+              <v-main>
+                <router-view />
+              </v-main>
+            </v-layout>
+          </v-card>
         </v-row>
-      </v-card>
+      </v-responsive>
     </v-main>
 
     <app-footer app class="pt-4" />

--- a/src/components/ChartDialog.vue
+++ b/src/components/ChartDialog.vue
@@ -2,8 +2,19 @@
   <div class="chart-dialog">
     <v-overlay v-model="$root.dialog" class="align-center justify-center">
       <div>
-        <v-card min-width="1100" class="pa-4">
-          <v-card-title class="text-h4" v-html="station.properties.name" />
+        <v-card
+          :width="$vuetify.display.width"
+          :max-height="$vuetify.display.height * 0.95"
+          max-width="1100"
+          class="pa-4 scroll"
+        >
+          <v-toolbar color="#FFF">
+            <v-card-title class="text-h4" v-html="station.properties.name" />
+            <v-spacer />
+            <v-btn varaint="text" color="pink" icon @click="$root.toggleDialog">
+              <v-icon icon="mdi-close"></v-icon>
+            </v-btn>
+          </v-toolbar>
           <v-card-subtitle v-html="station.id" />
           <v-responsive height="590">
             <data-viewer :station="station" />
@@ -41,3 +52,9 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.scroll {
+   overflow-y: scroll
+}
+</style>

--- a/src/components/app/AppHeader.vue
+++ b/src/components/app/AppHeader.vue
@@ -12,15 +12,13 @@
         <v-row justify="center">
           <v-responsive width="90%" max-width="1130">
             <v-container fluid>
-              <v-row>
-                <v-spacer />
-                <token-auth class="pt-4" />
-                <select-locale class="pt-4 pr-4" />
-              </v-row>
-              <v-row>
+              <v-row align="start">
                 <a :href="wis2" title="wis2box">
-                  <img :src="logo" class="px-4 pb-6" />
+                  <img :src="logo" class="pl-8 py-auto" />
                 </a>
+                <v-spacer />
+                <token-auth class="mt-n2" />
+                <select-locale class="mt-n2 pr-8" />
               </v-row>
             </v-container>
           </v-responsive>

--- a/src/components/app/AppHeader.vue
+++ b/src/components/app/AppHeader.vue
@@ -9,20 +9,23 @@
       </template>
 
       <template v-slot:default>
-        <v-row justify="center">
-          <v-responsive width="90%" max-width="1130">
-            <v-container fluid>
-              <v-row align="start">
-                <a :href="wis2" title="wis2box">
-                  <img :src="logo" class="pl-8 py-auto" />
-                </a>
-                <v-spacer />
-                <token-auth class="mt-n2" />
-                <select-locale class="mt-n2 pr-8" />
-              </v-row>
-            </v-container>
-          </v-responsive>
-        </v-row>
+        <v-responsive
+          width="90%"
+          max-width="1130"
+          height="100%"
+          class="mx-auto"
+        >
+          <v-container fluid>
+            <v-row align="start" fill-height>
+              <a :href="wis2" title="wis2box">
+                <img :src="logo" class="pl-6 my-3" />
+              </a>
+              <v-spacer />
+              <token-auth />
+              <select-locale class="pr-6" />
+            </v-row>
+          </v-container>
+        </v-responsive>
       </template>
     </v-app-bar>
   </div>

--- a/src/components/app/AppNav.vue
+++ b/src/components/app/AppNav.vue
@@ -1,30 +1,28 @@
 <template id="app-nav">
   <div class="app-nav">
     <v-app-bar flat>
-      <v-responsive class="mx-auto" width="90%" max-width="1130">
-        <v-btn-toggle divided>
-          <template v-for="(item, i) in items" :key="i">
-            <v-hover v-slot="{ isHovering, props }">
-              <v-btn
-                :href="item.href"
-                :to="item.target"
-                :target="`_window_${item.text}`"
-                :color="isHovering ? '#014e9e' : undefined"
-                class="font-weight-bold"
-                variant="text"
-                v-bind="props"
-              >
-                {{ $t(`navigation.${item.text}`) }}
-                <v-icon
-                  v-if="item.href !== undefined"
-                  end
-                  icon="mdi-open-in-new"
-                />
-              </v-btn>
-            </v-hover>
-          </template>
-        </v-btn-toggle>
-      </v-responsive>
+      <v-btn-toggle divided>
+        <template v-for="(item, i) in items" :key="i">
+          <v-hover v-slot="{ isHovering, props }">
+            <v-btn
+              :href="item.href"
+              :to="item.target"
+              :target="`_window_${item.text}`"
+              :color="isHovering ? '#014e9e' : undefined"
+              class="font-weight-bold"
+              variant="text"
+              v-bind="props"
+            >
+              {{ $t(`navigation.${item.text}`) }}
+              <v-icon
+                v-if="item.href !== undefined"
+                end
+                icon="mdi-open-in-new"
+              />
+            </v-btn>
+          </v-hover>
+        </template>
+      </v-btn-toggle>
     </v-app-bar>
   </div>
 </template>

--- a/src/components/app/TokenAuth.vue
+++ b/src/components/app/TokenAuth.vue
@@ -70,6 +70,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style>
-</style>

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -1,6 +1,6 @@
 <template id="data-navigation">
   <div class="data-navigation">
-    <v-navigation-drawer floating permanent absolute class="text-center">
+    <v-navigation-drawer v-model="drawer_" bottom absolute class="text-center">
       <v-list-item-subtitle
         class="mt-2"
         v-html="$t('chart.observed_property')"
@@ -37,13 +37,18 @@ import { getNameTime, hasLinks } from "@/scripts/helpers.js";
 export default {
   name: "DataNavigation",
   template: "#data-navigation",
-  props: ["choices", "alert", "station"],
+  props: ["choices", "alert", "station", "drawer"],
   data() {
     return {
       choices_: this.choices,
       alert_: this.alert,
       model: -1,
     };
+  },
+  computed: {
+    drawer_: function () {
+      return this.drawer.model;
+    },
   },
   watch: {
     "choices.collections": {

--- a/src/components/data/DataNavigation.vue
+++ b/src/components/data/DataNavigation.vue
@@ -18,7 +18,7 @@
             class="text-left text-body-2"
             @click="updateData(item, i)"
           >
-            {{ $root.parseForNameAndTime(item) }}
+            {{ getNameTime(item) }}
           </v-list-item>
           <v-divider
             class="pb-1 mx-2"
@@ -32,6 +32,7 @@
 
 <script>
 let oapi = window.VUE_APP_OAPI;
+import { getNameTime, hasLinks } from "@/scripts/helpers.js";
 
 export default {
   name: "DataNavigation",
@@ -47,7 +48,7 @@ export default {
   watch: {
     "choices.collections": {
       handler(c) {
-        if (this.station.links.length > 0) {
+        if (hasLinks(this.station)) {
           for (const item of c) {
             if (this.station.links[0].title === item.id) {
               this.updateCollection(item);
@@ -59,6 +60,7 @@ export default {
     },
   },
   methods: {
+    getNameTime,
     async updateCollection(newC) {
       this.alert_value = false;
       this.choices_.collection = newC;
@@ -126,7 +128,7 @@ export default {
       this.choices_.datastream = {
         id: newD.name,
         index: newD.index,
-        name: this.$root.parseForNameAndTime(newD),
+        name: getNameTime(newD),
         units: newD.units,
       };
       this.model = index;

--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -7,11 +7,9 @@
         <v-progress-linear striped indeterminate color="primary" />
       </div>
       <div :style="{ visibility: !loading ? 'visible' : 'hidden' }">
-        <v-container>
-          <v-row justify="center" align="end">
-            <div :id="'plotly-chart-' + choices_.collection.id" />
-          </v-row>
-        </v-container>
+        <v-card class="mx-auto" flat>
+          <div :id="'plotly-chart-' + choices_.collection.id" />
+        </v-card>
       </div>
     </v-card>
   </div>
@@ -84,6 +82,7 @@ export default defineComponent({
         },
       },
       config: {
+        responsive: true,
         displayModeBar: true,
         modeBarButtonsToAdd: [],
         modeBarButtonsToRemove: [

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -96,6 +96,7 @@ export default defineComponent({
       },
       config: {
         editable: false,
+        responsive: true,
         displayModeBar: true,
         modeBarButtonsToAdd: [],
         modeBarButtonsToRemove: [
@@ -202,7 +203,10 @@ export default defineComponent({
             self.plot(response.request.responseURL);
             if (datastream.units === "CODE TABLE") {
               self.title = `${datastream.name}`;
-              self.data.value = self.getCol(response.data.features, "description");
+              self.data.value = self.getCol(
+                response.data.features,
+                "description"
+              );
             } else {
               self.title = `${datastream.name} (${datastream.units})`;
               self.data.value = self.getCol(response.data.features, "value");

--- a/src/components/data/DataViewer.vue
+++ b/src/components/data/DataViewer.vue
@@ -2,7 +2,10 @@
   <div class="data-viewer">
     <v-layout>
       <v-app-bar color="#EEEEEE" flat>
-        <v-toolbar-title class="pa-2 text-h6">
+        <template v-slot:prepend v-if="$vuetify.display.smAndDown">
+          <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
+        </template>
+        <v-toolbar-title v-show="$vuetify.display.mdAndUp" class="pa-2 text-h6">
           {{ choices.collection.description || $t("chart.collection") }}
         </v-toolbar-title>
         <v-tabs v-model="tab" end color="#014e9e">
@@ -16,7 +19,12 @@
           </v-tab>
         </v-tabs>
       </v-app-bar>
-      <data-navigation :choices="choices" :station="station" :alert="alert" />
+      <data-navigation
+        :choices="choices"
+        :station="station"
+        :alert="alert"
+        :drawer="{ model: drawer }"
+      />
       <v-main>
         <v-window v-model="tab">
           <v-window-item :value="0">
@@ -70,6 +78,15 @@ export default defineComponent({
   methods: {
     goBack() {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push("/");
+    },
+  },
+  watch: {
+    "choices.datastream": {
+      handler(datastream) {
+        if (datastream !== "" && this.$vuetify.display.smAndDown) {
+          this.drawer = false;
+        }
+      },
     },
   },
   async created() {

--- a/src/components/leaflet/WisMap.vue
+++ b/src/components/leaflet/WisMap.vue
@@ -22,7 +22,11 @@
                   <wis-station :features="features" :map="map" />
                   <l-tile-layer :url="url" :attribution="attribution" />
                   <l-control position="bottomright">
-                    <v-card width="140px" class="legend pa-2">
+                    <v-card
+                      width="140px"
+                      class="legend pa-2"
+                      border="1"
+                    >
                       <strong> {{ $t("messages.no_of_observations") }} </strong>
                       <v-divider class="my-2" />
                       <v-row
@@ -148,7 +152,7 @@ export default defineComponent({
           var bounds_ = geoJSON(self.features_.stations).getBounds();
           self.map.fitBounds(bounds_);
           self.loading = false;
-          setTimeout(self.loadStations, 60000);
+          setTimeout(self.loadStations, 900000);
         });
     },
   },

--- a/src/components/leaflet/WisMap.vue
+++ b/src/components/leaflet/WisMap.vue
@@ -4,52 +4,48 @@
       <v-progress-linear striped indeterminate color="primary" />
     </div>
     <div class="text-center">
-      <v-layout>
-        <station-info :features="features" :map="map" />
-        <v-row justify="center" fill-height>
-          <v-main>
-            <v-card class="ma-4">
-              <p>
-                <l-map
-                  ref="wisMap"
-                  :zoom="zoom"
-                  :center="center"
-                  maxZoom="16"
-                  minZoom="2"
-                  style="height: 60vh"
-                  @ready="onReady()"
-                >
-                  <wis-station :features="features" :map="map" />
-                  <l-tile-layer :url="url" :attribution="attribution" />
-                  <l-control position="bottomright">
-                    <v-card
-                      width="140px"
-                      class="legend pa-2"
-                      border="1"
+      <v-row justify="center" fill-height no-gutters>
+        <v-col :cols="smAndDown ? 12 : 4" :order="smAndDown ? 'last' : 'start'">
+          <station-info :features="features" :map="map" class="ma-1" />
+        </v-col>
+        <v-col :cols="smAndDown ? 12 : 8">
+          <v-card class="ma-1">
+            <p>
+              <l-map
+                ref="wisMap"
+                :zoom="zoom"
+                :center="center"
+                maxZoom="16"
+                minZoom="2"
+                style="height: 60vh"
+                @ready="onReady()"
+              >
+                <wis-station :features="features" :map="map" />
+                <l-tile-layer :url="url" :attribution="attribution" />
+                <l-control position="bottomleft">
+                  <v-card width="124px" class="legend pa-2" border="1">
+                    <strong> {{ $t("messages.no_of_observations") }} </strong>
+                    <v-divider class="my-2" />
+                    <v-row
+                      no-gutters
+                      justify="center"
+                      v-for="(item, i) in legend"
+                      :key="i"
                     >
-                      <strong> {{ $t("messages.no_of_observations") }} </strong>
-                      <v-divider class="my-2" />
-                      <v-row
-                        no-gutters
-                        justify="center"
-                        v-for="(item, i) in legend"
-                        :key="i"
-                      >
-                        <v-col>
-                          <i class="dot" :style="`background: ${item.color}`" />
-                        </v-col>
-                        <v-col>
-                          {{ item.range }}
-                        </v-col>
-                      </v-row>
-                    </v-card>
-                  </l-control>
-                </l-map>
-              </p>
-            </v-card>
-          </v-main>
-        </v-row>
-      </v-layout>
+                      <v-col cols="3">
+                        <i class="dot" :style="`background: ${item.color}`" />
+                      </v-col>
+                      <v-col>
+                        {{ item.range }}
+                      </v-col>
+                    </v-row>
+                  </v-card>
+                </l-control>
+              </l-map>
+            </p>
+          </v-card>
+        </v-col>
+      </v-row>
     </div>
   </div>
 </template>
@@ -122,6 +118,9 @@ export default defineComponent({
       }
       items.add(this.numberMatched);
       return items;
+    },
+    smAndDown: function () {
+      return this.$vuetify.display.smAndDown;
     },
   },
   methods: {

--- a/src/components/station/StationHistory.vue
+++ b/src/components/station/StationHistory.vue
@@ -7,7 +7,10 @@
       <v-progress-linear height="6" indeterminate color="primary" />
     </div>
     <v-row justify="center">
-      <div id="station-history-plot" />
+      <div
+        class="plot-history"
+        :id="'station-history-' + wigos_station_identifier"
+      />
     </v-row>
   </div>
 </template>
@@ -55,12 +58,24 @@ export default defineComponent({
       },
     };
   },
+  computed: {
+    station: function () {
+      return this.features_.station;
+    },
+    wigos_station_identifier: function () {
+      if (this.station) {
+        return this.station.properties.wigos_station_identifier;
+      } else {
+        return "";
+      }
+    },
+  },
   watch: {
     "features_.station": {
       async handler(station) {
         if (hasLinks(station)) {
           this.loadObservations(station);
-        } else if (station !== null){
+        } else if (station !== null) {
           this.msg = `
             ${clean(station.properties.name)} ${this.$t(
             "messages.no_linked_collections"
@@ -73,8 +88,7 @@ export default defineComponent({
     },
   },
   methods: {
-    plot() {
-      var plot = document.getElementById("station-history-plot");
+    plot(plot) {
       Plotly.purge(plot);
       Plotly.newPlot(plot, this.data, this.layout, this.config);
     },
@@ -136,8 +150,13 @@ export default defineComponent({
             size: 3600000,
           },
         };
-        self.data.push(trace);
-        self.plot();
+        var plot = document.getElementById(
+          "station-history-" + station.id
+        );
+        if (plot !== null) {
+          self.data.push(trace);
+          self.plot(plot);
+        }
       });
       this.loading = false;
     },
@@ -188,8 +207,13 @@ export default defineComponent({
               },
               name: date_,
             };
-            self.data.push(trace);
-            self.plot();
+            var plot = document.getElementById(
+              "station-history-" + station.id
+            );
+            if (plot !== null) {
+              self.data.push(trace);
+              self.plot(plot);
+            }
           }
         });
       }

--- a/src/components/station/StationHistory.vue
+++ b/src/components/station/StationHistory.vue
@@ -14,6 +14,7 @@
 
 <script>
 import Plotly from "plotly.js-dist-min";
+import { clean, hasLinks } from "@/scripts/helpers.js";
 
 import { defineComponent } from "vue";
 
@@ -57,16 +58,16 @@ export default defineComponent({
   watch: {
     "features_.station": {
       async handler(station) {
-        if (station.links.length === 0) {
+        if (hasLinks(station)) {
+          this.loadObservations(station);
+        } else if (station !== null){
           this.msg = `
-            ${this.$root.clean(station.properties.name)} ${this.$t(
+            ${clean(station.properties.name)} ${this.$t(
             "messages.no_linked_collections"
           )}. ${this.$t("messages.how_to_link_station")}`;
           this.snackbar = true;
           this.loading = false;
           this.tab = null;
-        } else {
-          this.loadObservations(station);
         }
       },
     },

--- a/src/components/station/StationHistory.vue
+++ b/src/components/station/StationHistory.vue
@@ -73,6 +73,12 @@ export default defineComponent({
   watch: {
     "features_.station": {
       async handler(station) {
+        if (station !== null) {
+          this.data = [];
+          for (var plot of document.getElementsByClassName("plot-history")) {
+            this.plot(plot);
+          }
+        }
         if (hasLinks(station)) {
           this.loadObservations(station);
         } else if (station !== null) {
@@ -82,7 +88,6 @@ export default defineComponent({
           )}. ${this.$t("messages.how_to_link_station")}`;
           this.snackbar = true;
           this.loading = false;
-          this.tab = null;
         }
       },
     },
@@ -150,9 +155,7 @@ export default defineComponent({
             size: 3600000,
           },
         };
-        var plot = document.getElementById(
-          "station-history-" + station.id
-        );
+        var plot = document.getElementById("station-history-" + station.id);
         if (plot !== null) {
           self.data.push(trace);
           self.plot(plot);
@@ -207,9 +210,7 @@ export default defineComponent({
               },
               name: date_,
             };
-            var plot = document.getElementById(
-              "station-history-" + station.id
-            );
+            var plot = document.getElementById("station-history-" + station.id);
             if (plot !== null) {
               self.data.push(trace);
               self.plot(plot);

--- a/src/components/station/StationInfo.vue
+++ b/src/components/station/StationInfo.vue
@@ -1,28 +1,27 @@
 <template id="station-info">
   <div class="station-info">
-    <v-navigation-drawer permanent :width="400">
+    <v-card flat height="60vh" class="scroll">
       <v-toolbar>
-        <template v-slot:prepend>
-          <v-toolbar-title class="ml-2">
-            {{ station_name || $t("chart.station") }}
-          </v-toolbar-title>
+        <v-toolbar-title>
+          {{ station_name || $t("chart.station") }}
+        </v-toolbar-title>
+
+        <template v-slot:prepend v-if="station !== null">
+          <v-btn icon @click="features_.station = null">
+            <v-icon icon="mdi-arrow-left"></v-icon>
+          </v-btn>
         </template>
 
-        <template v-slot:append v-if="station !== null">
+        <template v-slot:append v-if="station != null">
           <v-btn
-            class="my-auto"
             variant="outlined"
             size="small"
             color="#014e9e"
-            :target="station.id"
-            :title="station.id"
-            :href="station.properties.url"
+            @click.stop="openData(station)"
+            class="my-auto"
           >
-            OSCAR
-            <v-icon end icon="mdi-open-in-new"></v-icon>
-          </v-btn>
-          <v-btn color="pink" icon @click="features_.station = null">
-            <v-icon icon="mdi-close"></v-icon>
+            {{ $t("navigation.data") }}
+            <v-icon end icon="mdi-chart-scatter-plot" />
           </v-btn>
         </template>
       </v-toolbar>
@@ -34,7 +33,7 @@
       <v-card flat class="text-center" v-show="station !== null">
         <station-status :features="features" :map="map" />
       </v-card>
-    </v-navigation-drawer>
+    </v-card>
   </div>
 </template>
 
@@ -65,5 +64,17 @@ export default defineComponent({
       }
     },
   },
+  methods: {
+    openData(station) {
+      this.features_.station = station;
+      this.$root.toggleDialog();
+    },
+  },
 });
 </script>
+
+<style scoped>
+.scroll {
+  overflow-y: scroll;
+}
+</style>

--- a/src/components/station/StationInfo.vue
+++ b/src/components/station/StationInfo.vue
@@ -2,20 +2,32 @@
   <div class="station-info">
     <v-navigation-drawer permanent :width="400">
       <v-toolbar>
-        <h3 class="text-no-wrap mx-4">
-          {{ station_name || $t("chart.station") }}
-        </h3>
-        <v-spacer />
-        <v-btn
-          color="pink"
-          icon
-          v-show="station !== null"
-          @click="features_.station = null"
-        >
-          <v-icon icon="mdi-close"></v-icon>
-        </v-btn>
+        <template v-slot:prepend>
+          <v-toolbar-title class="ml-2">
+            {{ station_name || $t("chart.station") }}
+          </v-toolbar-title>
+        </template>
+
+        <template v-slot:append>
+          <v-toolbar-items v-if="station !== null">
+            <v-btn
+              variant="outlined"
+              size="small"
+              color="#014e9e"
+              :target="station.id"
+              :title="station.id"
+              :href="station.properties.url"
+            >
+              OSCAR
+              <v-icon end icon="mdi-open-in-new"></v-icon>
+            </v-btn>
+            <v-btn color="pink" icon @click="features_.station = null">
+              <v-icon icon="mdi-close"></v-icon>
+            </v-btn>
+          </v-toolbar-items>
+        </template>
       </v-toolbar>
-      <v-divider />
+
       <v-card flat class="text-center" v-show="station === null">
         <station-list :features="features" :map="map" />
       </v-card>

--- a/src/components/station/StationInfo.vue
+++ b/src/components/station/StationInfo.vue
@@ -8,23 +8,22 @@
           </v-toolbar-title>
         </template>
 
-        <template v-slot:append>
-          <v-toolbar-items v-if="station !== null">
-            <v-btn
-              variant="outlined"
-              size="small"
-              color="#014e9e"
-              :target="station.id"
-              :title="station.id"
-              :href="station.properties.url"
-            >
-              OSCAR
-              <v-icon end icon="mdi-open-in-new"></v-icon>
-            </v-btn>
-            <v-btn color="pink" icon @click="features_.station = null">
-              <v-icon icon="mdi-close"></v-icon>
-            </v-btn>
-          </v-toolbar-items>
+        <template v-slot:append v-if="station !== null">
+          <v-btn
+            class="my-auto"
+            variant="outlined"
+            size="small"
+            color="#014e9e"
+            :target="station.id"
+            :title="station.id"
+            :href="station.properties.url"
+          >
+            OSCAR
+            <v-icon end icon="mdi-open-in-new"></v-icon>
+          </v-btn>
+          <v-btn color="pink" icon @click="features_.station = null">
+            <v-icon icon="mdi-close"></v-icon>
+          </v-btn>
         </template>
       </v-toolbar>
 

--- a/src/components/station/StationLatest.vue
+++ b/src/components/station/StationLatest.vue
@@ -7,8 +7,12 @@
       <table>
         <tr v-for="(item, i) in recentObservations" :key="i">
           <th width="50%">{{ getNameTime(item) }}</th>
-          <td v-if="item.units !== 'CODE TABLE'" width="50%">{{ item.value + " " + item.units }}</td>
-          <td v-else-if="item.units === 'CODE TABLE'" width="50%">{{ item.description }}</td>
+          <td v-if="item.units !== 'CODE TABLE'" width="50%">
+            {{ item.value + " " + item.units }}
+          </td>
+          <td v-else-if="item.units === 'CODE TABLE'" width="50%">
+            {{ item.description }}
+          </td>
         </tr>
       </table>
     </v-table>
@@ -34,9 +38,11 @@ export default defineComponent({
   watch: {
     "features_.station": {
       async handler(station) {
+        this.latestResultTime = null;
+        this.recentObservations = [];
         if (hasLinks(station)) {
           this.loadObservations(station);
-        } else if (station !== null){
+        } else if (station !== null) {
           this.msg = `
             ${clean(station.properties.name)} ${this.$t(
             "messages.no_linked_collections"

--- a/src/components/station/StationLatest.vue
+++ b/src/components/station/StationLatest.vue
@@ -6,7 +6,7 @@
     <v-table>
       <table>
         <tr v-for="(item, i) in recentObservations" :key="i">
-          <th width="50%">{{ $root.parseForNameAndTime(item) }}</th>
+          <th width="50%">{{ getNameTime(item) }}</th>
           <td v-if="item.units !== 'CODE TABLE'" width="50%">{{ item.value + " " + item.units }}</td>
           <td v-else-if="item.units === 'CODE TABLE'" width="50%">{{ item.description }}</td>
         </tr>
@@ -17,6 +17,8 @@
 
 <script>
 import { defineComponent } from "vue";
+
+import { getNameTime, clean, hasLinks } from "@/scripts/helpers.js";
 
 export default defineComponent({
   name: "StationLatest",
@@ -32,21 +34,22 @@ export default defineComponent({
   watch: {
     "features_.station": {
       async handler(station) {
-        if (station.links.length === 0) {
+        if (hasLinks(station)) {
+          this.loadObservations(station);
+        } else if (station !== null){
           this.msg = `
-            ${this.$root.clean(station.properties.name)} ${this.$t(
+            ${clean(station.properties.name)} ${this.$t(
             "messages.no_linked_collections"
           )}. ${this.$t("messages.how_to_link_station")}`;
           this.snackbar = true;
           this.loading = false;
           this.tab = null;
-        } else {
-          this.loadObservations(station);
         }
       },
     },
   },
   methods: {
+    getNameTime,
     async loadObservations(station) {
       var self = this;
       await this.$http({

--- a/src/components/station/StationList.vue
+++ b/src/components/station/StationList.vue
@@ -10,7 +10,7 @@
           @click="onClick(s)"
           @mouseover="onHover(s)"
         >
-          <h4 class="text-left" v-html="$root.clean(s.properties.name)" />
+          <h4 class="text-left" v-html="clean(s.properties.name)" />
           <template v-slot:append>
             <v-btn
               variant="outlined"
@@ -43,6 +43,8 @@
 <script>
 import { defineComponent } from "vue";
 
+import { clean } from "@/scripts/helpers.js";
+
 export default defineComponent({
   name: "StationList",
   template: "#station-list",
@@ -73,6 +75,7 @@ export default defineComponent({
     },
   },
   methods: {
+    clean,
     onClick(station) {
       this.features_.station = station;
       const latlng = [

--- a/src/components/station/StationList.vue
+++ b/src/components/station/StationList.vue
@@ -1,6 +1,6 @@
 <template id="station-list">
   <div class="station-list">
-    <v-list>
+    <v-list lines="3">
       <v-hover v-slot="{ isHovering, props }">
         <template v-for="(s, i) in stations" :key="i">
           <v-list-item
@@ -15,7 +15,7 @@
             </template>
 
             <template v-slot:title>
-              <h4 class="mx-2 text-left" v-text="clean(s.properties.name)" />
+              <h4 class="ml-1 text-left" v-text="clean(s.properties.name)" />
             </template>
 
             <template v-slot:append>
@@ -23,11 +23,12 @@
                 variant="outlined"
                 size="small"
                 color="#014e9e"
-                @click.stop="openData(s)"
-                class="mr-1"
+                :target="s.id"
+                :title="s.id"
+                :href="s.properties.url"
               >
-                {{ $t("navigation.data") }}
-                <v-icon end icon="mdi-chart-scatter-plot"></v-icon>
+                OSCAR
+                <v-icon end icon="mdi-open-in-new" />
               </v-btn>
             </template>
           </v-list-item>
@@ -88,10 +89,6 @@ export default defineComponent({
         station.geometry.coordinates[0],
       ];
       this.map.openPopup(station.properties.name, latlng);
-    },
-    openData(station) {
-      this.features_.station = station;
-      this.$root.toggleDialog();
     },
     getColor(station) {
       let hits = station.properties.num_obs;

--- a/src/components/station/StationList.vue
+++ b/src/components/station/StationList.vue
@@ -2,39 +2,33 @@
   <div class="station-list">
     <v-list>
       <v-hover v-slot="{ isHovering, props }">
-        <v-list-item
-          v-for="(s, i) in stations"
-          :key="i"
-          v-bind="props"
-          :class="{ 'on-hover': isHovering }"
-          @click="onClick(s)"
-          @mouseover="onHover(s)"
-        >
-          <h4 class="text-left" v-html="clean(s.properties.name)" />
-          <template v-slot:append>
-            <v-btn
-              variant="outlined"
-              size="small"
-              color="#014e9e"
-              @click.stop="openData(s)"
-              class="mx-3"
-            >
-              {{ $t("navigation.data") }}
-              <v-icon end icon="mdi-chart-scatter-plot"></v-icon>
-            </v-btn>
-            <v-btn
-              variant="outlined"
-              size="small"
-              color="#014e9e"
-              :target="s.id"
-              :title="s.id"
-              :href="s.properties.url"
-            >
-              OSCAR
-              <v-icon end icon="mdi-open-in-new"></v-icon>
-            </v-btn>
-          </template>
-        </v-list-item>
+        <template v-for="(s, i) in stations" :key="i">
+          <v-list-item
+            v-bind="props"
+            lines="3"
+            :class="{ 'on-hover': isHovering }"
+            @click="onClick(s)"
+            @mouseover="onHover(s)"
+          >
+            <template v-slot:title class="mx-1">
+              <h4 v-html="clean(s.properties.name)" />
+              <i class="dot" :style="`background: ${getColor(s)}`" />
+            </template>
+            <template v-slot:append>
+              <v-btn
+                variant="outlined"
+                size="small"
+                color="#014e9e"
+                @click.stop="openData(s)"
+                class="mr-1"
+              >
+                {{ $t("navigation.data") }}
+                <v-icon end icon="mdi-chart-scatter-plot"></v-icon>
+              </v-btn>
+            </template>
+          </v-list-item>
+          <v-divider v-if="i+1 < stations.length" />
+        </template>
       </v-hover>
     </v-list>
   </div>
@@ -95,6 +89,28 @@ export default defineComponent({
       this.features_.station = station;
       this.$root.toggleDialog();
     },
+    getColor(station) {
+      let hits = station.properties.num_obs;
+      if (hits === 0) {
+        return "#708090";
+      } else if (hits <= 7) {
+        return "#FF3300";
+      } else if (hits <= 19) {
+        return "#FF9900";
+      } else {
+        return "#009900";
+      }
+    },
   },
 });
 </script>
+
+<style scoped>
+.dot {
+  height: 16px;
+  width: 16px;
+  display: inline-block;
+  border-radius: 50%;
+  opacity: 0.8;
+}
+</style>

--- a/src/components/station/StationList.vue
+++ b/src/components/station/StationList.vue
@@ -5,15 +5,19 @@
         <template v-for="(s, i) in stations" :key="i">
           <v-list-item
             v-bind="props"
-            lines="3"
+            height="50"
             :class="{ 'on-hover': isHovering }"
             @click="onClick(s)"
             @mouseover="onHover(s)"
           >
-            <template v-slot:title class="mx-1">
-              <h4 v-html="clean(s.properties.name)" />
+            <template v-slot:prepend>
               <i class="dot" :style="`background: ${getColor(s)}`" />
             </template>
+
+            <template v-slot:title>
+              <h4 class="mx-2 text-left" v-text="clean(s.properties.name)" />
+            </template>
+
             <template v-slot:append>
               <v-btn
                 variant="outlined"
@@ -27,7 +31,7 @@
               </v-btn>
             </template>
           </v-list-item>
-          <v-divider v-if="i+1 < stations.length" />
+          <v-divider v-if="i + 1 < stations.length" />
         </template>
       </v-hover>
     </v-list>

--- a/src/components/station/WisStation.vue
+++ b/src/components/station/WisStation.vue
@@ -11,7 +11,6 @@
 <script>
 import { circleMarker } from "leaflet/dist/leaflet-src.esm";
 import { LGeoJson } from "@vue-leaflet/vue-leaflet";
-import { hasLinks } from "@/scripts/helpers.js";
 
 import { defineComponent } from "vue";
 
@@ -49,7 +48,7 @@ export default defineComponent({
       let fillColor;
       let color;
       let hits = feature.properties.num_obs;
-      if (hits === 0){
+      if (hits === 0) {
         fillColor = "#708090";
         color = "#2E343B";
       } else if (hits <= 7) {

--- a/src/components/station/WisStation.vue
+++ b/src/components/station/WisStation.vue
@@ -11,6 +11,7 @@
 <script>
 import { circleMarker } from "leaflet/dist/leaflet-src.esm";
 import { LGeoJson } from "@vue-leaflet/vue-leaflet";
+import { hasLinks } from "@/scripts/helpers.js";
 
 import { defineComponent } from "vue";
 

--- a/src/locales/_template.json
+++ b/src/locales/_template.json
@@ -55,6 +55,7 @@
     "oafeat": "",
     "oarec": "",
     "map": "",
+    "explore": "",
     "mqp": ""
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,6 +55,7 @@
     "oafeat": "Observations",
     "oarec": "Discovery metadata",
     "map": "Map",
+    "explore": "Explore",
     "mqp": "PubSub"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -55,6 +55,7 @@
     "oafeat": "Observaciones",
     "oarec": "Metadatos de descubrimiento",
     "map": "Mapa",
+    "explore": "Explorar",
     "mqp": "PubSub"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -55,6 +55,7 @@
     "oafeat": "Observations",
     "oarec": "Métadonnées de découverte",
     "map": "Carte",
+    "explore": "Explorer",
     "mqp": "PubSub"
   }
 }

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -1,0 +1,43 @@
+export function getNameTime(feature, time_field = "phenomenonTime") {
+  var name = clean(feature.name);
+
+  if (feature[time_field].includes("/")) {
+    const splitTime = feature[time_field].split("/");
+    var timeDifference =
+      new Date(splitTime[1]).getTime() - new Date(splitTime[0]).getTime();
+    var minuteDifference = Math.floor(timeDifference / (1000 * 60));
+    var hourDifference = Math.floor(timeDifference / (1000 * 3600));
+
+    if (hourDifference > 0) {
+      name = `${name} (${hourDifference} hr)`;
+    } else if (minuteDifference > 0) {
+      name = `${name} (${minuteDifference} min)`;
+    }
+  }
+
+  return name;
+}
+
+export function clean(word) {
+  if (typeof word === "string") {
+    if (word.search(/\d+$/) > -1) {
+      // String ends with a number
+      var endingNumber = word.match(/\d+$/g);
+      word = word.replace(endingNumber, `_${endingNumber}`);
+    }
+
+    if (word.search(/^\d+/) > -1) {
+      // String starts with a number
+      var leadingNumber = word.match(/^\d+/g);
+      word = word.replace(leadingNumber, `${leadingNumber}_`);
+    } else {
+      word = word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+    }
+
+    return word.replaceAll("_", " ");
+  }
+}
+
+export function hasLinks(feature) {
+  return feature && feature.links && feature.links.length > 0;
+}

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -5,68 +5,79 @@
         <h2>{{ $t("messages.welcome") }}</h2>
       </v-alert>
       <v-card class="pa-2">
-        <v-table>
-          <tbody>
-            <tr class="pa-2 my-4" v-for="(item, i) in datasets" :key="i">
-              <th>
-                <v-hover v-slot="{ isHovering, props }">
-                  <v-container>
-                    <v-row justify="center" fill-height>
-                      <v-card
-                        class="pa-0 ma-0"
-                        :elevation="isHovering ? 24 : 0"
-                        v-bind="props"
-                        @click="loadMap(item.id)"
-                      >
-                        <v-overlay
-                          open-on-hover
-                          contained
-                          activator="parent"
-                          class="align-center justify-center"
-                        >
-                          <v-btn flat>
-                            {{ $t("datasets.map") }}
-                          </v-btn>
-                        </v-overlay>
-                        <dataset-map :dataset="item" />
-                      </v-card>
-                    </v-row>
-                  </v-container>
-                </v-hover>
-              </th>
-              <td>
-                <v-col cols="12" class="text-center">
-                  <h2>
-                    {{ item.properties.title }}
-                  </h2>
-                  <span>
-                    <strong>{{ $t("datasets.topic") + " : " }}</strong>
-                    <code>{{ item.id }}</code>
-                  </span>
-                </v-col>
-                <v-col cols="12" class="text-center">
-                  <v-btn-group variant="outlined" divided>
-                    <v-btn
-                      v-for="(item, i) in item.links"
-                      :key="i"
-                      :title="item.type"
-                      :href="item.href"
-                      :to="item.target"
-                      :target="`_window_${item.type}`"
-                    >
-                      {{ $t(`datasets.${item.msg}`) }}
-                      <v-icon
-                        v-if="item.href !== undefined"
-                        end
-                        icon="mdi-open-in-new"
-                      />
+        <v-row v-for="(item, i) in datasets" :key="i">
+          <v-col sm="12" md="3">
+            <v-container>
+              <v-row justify="center" fill-height>
+                <v-card class="pa-0 ma-0" @click="loadMap(item.id)">
+                  <v-overlay
+                    open-on-hover
+                    contained
+                    activator="parent"
+                    class="align-center justify-center"
+                  >
+                    <v-btn flat>
+                      {{ $t("datasets.map") }}
                     </v-btn>
-                  </v-btn-group>
-                </v-col>
-              </td>
-            </tr>
-          </tbody>
-        </v-table>
+                  </v-overlay>
+                  <dataset-map :dataset="item" />
+                </v-card>
+              </v-row>
+            </v-container>
+          </v-col>
+          <v-col sm="12" md="9" class="text-center">
+            <v-col>
+              <h2>
+                {{ item.properties.title }}
+              </h2>
+            </v-col>
+            <v-col class="flex-nowrap">
+              <span class="pt-2">
+                <strong>{{ $t("datasets.topic") + " : " }}</strong>
+                <code>{{ item.id }}</code>
+              </span>
+            </v-col>
+            <v-col>
+              <v-btn-group
+                v-show="$vuetify.display.mdAndUp"
+                variant="outlined"
+                divided
+              >
+                <v-btn
+                  v-for="(item, i) in item.links"
+                  :key="i"
+                  :title="item.type"
+                  :href="item.href"
+                  :to="item.target"
+                  :target="`_window_${item.type}`"
+                >
+                  {{ $t(`datasets.${item.msg}`) }}
+                  <v-icon end :icon="item.icon" />
+                </v-btn>
+              </v-btn-group>
+              <v-row
+                v-show="$vuetify.display.smAndDown"
+                v-for="(item, i) in item.links"
+                :key="i"
+                justify="center"
+                class="my-1"
+              >
+                <v-btn
+                  block
+                  variant="outlined"
+                  :title="item.type"
+                  :href="item.href"
+                  :to="item.target"
+                  :target="`_window_${item.type}`"
+                >
+                  {{ $t(`datasets.${item.msg}`) }}
+                  <v-icon end :icon="item.icon" />
+                </v-btn>
+              </v-row>
+            </v-col>
+          </v-col>
+          <v-divider v-if="i + 1 < datasets.length" />
+        </v-row>
       </v-card>
     </v-card>
   </div>
@@ -94,7 +105,15 @@ export default {
     );
     const data = await response.json();
     for (var c of data.features) {
-      const links = [];
+      const links = [
+        {
+          href: undefined,
+          target: `/${c.id}`,
+          type: "Map",
+          msg: "explore",
+          icon: "mdi-map-marker-circle",
+        },
+      ];
       for (var link of c.links) {
         if (link.type === "OARec") {
           links.push({
@@ -102,6 +121,7 @@ export default {
             target: undefined,
             type: "OARec",
             msg: "oarec",
+            icon: "mdi-open-in-new",
           });
         } else if (link.type === "OAFeat") {
           links.push({
@@ -109,15 +129,10 @@ export default {
             target: undefined,
             type: "OAFeat",
             msg: "oafeat",
+            icon: "mdi-open-in-new",
           });
         }
       }
-      links.push({
-        href: undefined,
-        target: `/${c.id}`,
-        type: "Map",
-        msg: "map",
-      });
       c.bbox = [
         c.geometry.coordinates[0][0][0],
         c.geometry.coordinates[0][0][1],

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -1,6 +1,6 @@
 <template id="datasets">
   <div class="datasets">
-    <v-responsive justify-center>
+    <v-card flat>
       <v-alert border="start" variant="contained-text" color="#014e9e">
         <h2>{{ $t("messages.welcome") }}</h2>
       </v-alert>
@@ -68,7 +68,7 @@
           </tbody>
         </v-table>
       </v-card>
-    </v-responsive>
+    </v-card>
   </div>
 </template>
 


### PR DESCRIPTION
Mobile version demonstrated on iPhone XR

- Datasets view
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/40066515/197755216-d0bb823d-7f83-40fc-a7bc-7f9c6096afc9.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/40066515/197755258-1b0e78af-33fd-47af-8d20-9c03381b9fec.png">

- Dataset map & explorer
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/40066515/197755460-6d460a8a-6a38-4650-8b11-1ab5284d855f.png">
<img width="639" alt="image" src="https://user-images.githubusercontent.com/40066515/197756371-fa0d1f5c-3372-4e60-98ff-d9e41a8b2307.png">
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/40066515/197756482-75614eac-737c-46ac-9ca5-d545cd62cd98.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/40066515/197756517-1c70a762-68e7-4e0f-9fbe-f0e323fff726.png">

- Data plotter dialog
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/40066515/197756587-ece6f2d1-7ebe-4875-89be-79590e990f79.png">
<img width="943" alt="image" src="https://user-images.githubusercontent.com/40066515/197756931-4ce29374-ac6b-413b-b3ff-60b1c51888e0.png">

- Cleanup performance of station info/history when hovering over a station with no observations. 
- Cleanup performance of station info/history when switching a station of interest is still loading.
- Move common helper methods to their own file.

