### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,7 +9,6 @@ http {
     default_type  application/octet-stream;
     server {
         listen 80;
-        listen [::]:80;
         server_name  localhost;
 
         location / {


### PR DESCRIPTION
no IPv6 required in container, wis2box-ui container service should be run behind a proxy and local binding can use IPv4  ?

https://github.com/wmo-im/wis2box/issues/745