### PR TITLE
Basic Lint and Type checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint Code
+
+on:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.3.0' 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linter
+        run: npm run lint

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -1,0 +1,26 @@
+name: Type Check
+
+on:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.3.0' 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run type checks
+        run: npm run type-check
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
- Start of basic CI/CD pipeline
- Make sure code passes build and has no linter errors before merging
- Does not use any actions outside of `actions/` provided by github directly