### PR TITLE
Add ci for docker build validation and npm tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Docker Build and Sanity Check
+
+on:
+  push:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        run: |
+          docker build -t wis2box-ui:test .
+
+      - name: Run Docker container
+        run: |
+          docker run -d --name wis2box-ui-test -p 8080:80 wis2box-ui:test
+          sleep 5 # Give the container time to start
+
+      - name: Test Nginx is running
+        run: |
+          curl -f http://localhost:8080 || (docker logs wis2box-ui-test && exit 1)
+
+      - name: Stop and remove container
+        if: always()
+        run: |
+          docker stop wis2box-ui-test || true
+          docker rm wis2box-ui-test || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Node Tests
+
+on:
+  push:
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.3.0' 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test:unit


### PR DESCRIPTION
- Test the docker container builds and is accessible via the nginx reverse proxy
- Test all npm tests

Will plan to add more tests for each. This is just the start of things and is moreso a baseline to make sure things stay valid as I iterate in the future