### PR TITLE
Small fixes

### DIFF
--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -12,7 +12,7 @@
         </v-row>
       </v-container>
 
-      <v-table v-show="title !== ''" fixed-header height="500px">
+      <v-table v-show="title !== ''" fixed-header height="470px">
         <thead>
           <tr>
             <th class="text-center">

--- a/src/components/station/StationInfo.vue
+++ b/src/components/station/StationInfo.vue
@@ -9,8 +9,8 @@
         {{ selectedStation?.properties.name || $t("chart.station") }}
       </v-toolbar-title>
 
-      <template v-slot:prepend v-if="selectedStation">
-        <v-btn icon @click="store.clearSelectedStation">
+      <template v-slot:prepend>
+        <v-btn icon @click="selectedStation ? store.clearSelectedStation() : $router.push('/')">
           <v-icon icon="mdi-arrow-left"></v-icon>
         </v-btn>
       </template>


### PR DESCRIPTION
Fix table spacing
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/2f0d9686-ed4c-4941-93fb-f76ad046d18d" />
is now 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a7b689af-c34d-40b2-982c-53b850446bb5" />

Added back arrow to stationInfo to route to datasets view
<img width="393" alt="image" src="https://github.com/user-attachments/assets/bbfab6f7-c27f-4e80-bae3-af42cf8abdc9" />
is now
<img width="404" alt="image" src="https://github.com/user-attachments/assets/a152221d-60a8-42c2-8533-07f1edbaf310" />
