### PR TITLE
A11y improvement for error message

### DIFF
--- a/src/components/app/AppMsg.vue
+++ b/src/components/app/AppMsg.vue
@@ -1,6 +1,15 @@
 <template id="app-msg">
   <v-overlay v-model="snackbar" class="align-center justify-center">
-    <v-card flat width="100%" max-width="1130" class="text-center">
+    <v-card 
+      flat 
+      width="100%" 
+      max-width="1130" 
+      class="text-center" 
+      aria-live="assertive" 
+      aria-atomic="true" 
+      role="alertdialog"
+      v-if="error.msg"
+    >
       <v-card-text>
         <template v-if="error.msg">
           <template v-for="(line, index) in splitMessage" :key="index">

--- a/src/views/DatasetView.vue
+++ b/src/views/DatasetView.vue
@@ -15,7 +15,7 @@
           <v-container>
             <v-row justify="center" fill-height>
               <template v-if="dataset.hasSynop">
-                <v-card class="pa-0 ma-0" @click="loadMap(dataset.id)">
+                <v-card class="pa-0 ma-0" @click="loadMap(dataset.id)" @keydown.enter="loadMap(dataset.id)" aria-label="Dataset map">
                   <v-overlay open-on-hover contained activator="parent" class="align-center justify-center">
                     <v-btn flat>
                       {{ $t("datasets.map") }}


### PR DESCRIPTION
Currently the error popup is not accessible and doesnt present itself to screen readers as a live element. Adding aria live semantically designates it as such and makes it better

Also added an aria label to the map and made it on on enter since previously it was not keyboard navigable 