### PR TITLE
remove filter on reportId from loadObservations

### DIFF
--- a/src/components/data/DataPlotter.vue
+++ b/src/components/data/DataPlotter.vue
@@ -142,7 +142,7 @@ export default defineComponent({
       this.data = [];
       this.loading = true;
       try {
-        const url = `${window.VUE_APP_OAPI}/collections/${this.topic}/items?f=json&name=${this.selectedDatastream.name}&reportId=${this.selectedDatastream.reportId}&wigos_station_identifier=${this.selectedStation.id}&sortby=reportTime`;
+        const url = `${window.VUE_APP_OAPI}/collections/${this.topic}/items?f=json&name=${this.selectedDatastream.name}&wigos_station_identifier=${this.selectedStation.id}&sortby=reportTime`;
 
         let response
         try {

--- a/src/components/data/DataTable.vue
+++ b/src/components/data/DataTable.vue
@@ -140,7 +140,7 @@ export default defineComponent({
       this.loading = true;
 
       try {
-        const url = `${window.VUE_APP_OAPI}/collections/${this.topic}/items?f=json&name=${this.selectedDatastream.name}&reportId=${this.selectedDatastream.reportId}&wigos_station_identifier=${this.selectedStation.id}&sortby=-reportTime`
+        const url = `${window.VUE_APP_OAPI}/collections/${this.topic}/items?f=json&name=${this.selectedDatastream.name}&wigos_station_identifier=${this.selectedStation.id}&sortby=-reportTime`
         const response = await fetchAllOAFFeatures(url);
         const data: ItemsResponse = await response.json();
         this.plot(response.url);


### PR DESCRIPTION
While checking my chart for my fake station where I've uploaded hundreds of fake hourly observations I noted it displayed only one point

I note that this because the underlying API-call generated by wis2box-ui is:
[https://wis2box-test.wis2dev.io/oapi/collections/urn:wmo:md:int-wmo-wis2box-latest:synop[…]ntifier=0-20000-0-00001&sortby=reportTime&resulttype=hits](https://wis2box-test.wis2dev.io/oapi/collections/urn:wmo:md:int-wmo-wis2box-latest:synop-100-stations/items?f=json&name=pressure_reduced_to_mean_sea_level&reportId=0-20000-0-00001-202504010000&wigos_station_identifier=0-20000-0-00001&sortby=reportTime&resulttype=hits)

Which returns only 1 hit because the code generated a URL for one specific hourly-report reportId=0-20000-0-00001-202504010000